### PR TITLE
Adding global config option to hide the Manager Window at startup.

### DIFF
--- a/src/qudi/core/application.py
+++ b/src/qudi/core/application.py
@@ -250,7 +250,8 @@ class Qudi(QtCore.QObject):
         if self.no_gui:
             return
         self.gui = Gui(qudi_instance=self, stylesheet_path=self.configuration.stylesheet)
-        self.gui.activate_main_gui()
+        if not self.configuration.hide_manager_window:
+            self.gui.activate_main_gui()
 
     def _start_startup_modules(self):
         for module in self.configuration.startup_modules:

--- a/src/qudi/core/config.py
+++ b/src/qudi/core/config.py
@@ -162,6 +162,25 @@ class Configuration(QtCore.QObject):
         self.sigConfigChanged.emit(self)
 
     @property
+    def hide_manager_window(self):
+        """ Flag indicating if the MainWindow of the qudi manager should be shown at startup.
+
+        @return bool: Shows the MainWindow of the qudi manager at startup
+        """
+        return self._global_config.get('hide_manager_window', False)
+
+    @hide_manager_window.setter
+    def hide_manager_window(self, flag):
+        """ Setter for a flag to hide the Manager Window.
+        By using the tray icon the Manager Window can be started at a later point in time.
+
+        @param bool hide_manager_window: Shows the MainWindow of the qudi manager at startup
+        """
+        assert isinstance(flag, bool), 'hide_manager_window flag must be bool type.'
+        self._global_config['hide_manager_window'] = flag
+        self.sigConfigChanged.emit(self)
+
+    @property
     def stylesheet(self):
         """ Absolute .qss file path used as stylesheet for qudi Qt application.
 
@@ -428,8 +447,8 @@ class Configuration(QtCore.QObject):
         new_config.daily_data_dirs = global_cfg.pop('daily_data_dirs', None)
         new_config.default_data_dir = global_cfg.pop('default_data_dir', None)
         new_config.namespace_server_port = global_cfg.pop('namespace_server_port', 18861)
-        new_config.force_remote_calls_by_value = global_cfg.pop('force_remote_calls_by_value',
-                                                                True)
+        new_config.force_remote_calls_by_value = global_cfg.pop('force_remote_calls_by_value', True)
+        new_config.hide_manager_window = global_cfg.pop('hide_manager_window', False)
         new_config.remote_modules_server = global_cfg.pop('remote_modules_server', None)
         if global_cfg:
             warn(f'Found additional entries in global config. The following entries will be '

--- a/src/qudi/core/gui/gui.py
+++ b/src/qudi/core/gui/gui.py
@@ -150,7 +150,7 @@ class Gui(QtCore.QObject):
         self._configure_pyqtgraph(use_opengl)
         self.main_gui_module = QudiMainGui(qudi_main_weakref=weakref.ref(qudi_instance),
                                            name='qudi_main_gui')
-        self.system_tray_icon.managerAction.triggered.connect(self.main_gui_module.show,
+        self.system_tray_icon.managerAction.triggered.connect(self.activate_main_gui,
                                                               QtCore.Qt.QueuedConnection)
         self.system_tray_icon.quitAction.triggered.connect(qudi_instance.quit,
                                                            QtCore.Qt.QueuedConnection)
@@ -243,11 +243,12 @@ class Gui(QtCore.QObject):
                                             QtCore.Qt.BlockingQueuedConnection)
             return
 
-        logger.info('Activating main GUI module...')
-        print('> Activating main GUI module...')
         if self.main_gui_module.module_state() != 'deactivated':
             self.main_gui_module.show()
             return
+
+        logger.info('Activating main GUI module...')
+        print('> Activating main GUI module...')
 
         self.main_gui_module.module_state.activate()
         QtWidgets.QApplication.instance().processEvents()


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

New global option added to NOT show the Manager Window at startup.

## Description
<!--- Describe your changes in detail -->

The default option of `hide_manager_window` is False and the Manager Window comes up to start/manage the other modules.
If this global option is set to True, the Manager Window stays closed and only windows in StartUp are brought up.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In some cases, only dedicated Modules should show up as windows, to hide the complexity of qudi under the hood. Here a Manager Window is not required.

It is however still possible to access the Manager Window or close qudi all-together: As the TrayIcon is started, a right click gives access to the Manager Window (among all other open Windows) and a left click allows for closing qudi (see Screenshots below).

![grafik](https://user-images.githubusercontent.com/18718646/152805997-2fa5083b-32a9-4bfb-bb3d-9873116741cf.png)
![grafik](https://user-images.githubusercontent.com/18718646/152806128-5ea47cb7-08c2-4b22-8959-0debd32c203a.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
