### PR TITLE
Parallel local qudi sessions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,9 @@ None
 None
 
 ### New Features
-None
+- Multiple qudi sessions can now be run in parallel locally. However, the user must ensure 
+non-conflicting socket server settings for namespace server and remote module server in the 
+configs to load.
 
 ### Other
 None


### PR DESCRIPTION
## Description
This small PR will allow to run multiple local qudi sessions in parallel.

## Motivation and Context
The rotating file handler of the qudi logging facility has prevented this before due to file access conflicts.
Now the qudi logger will detect if the log file is already owned by another qudi process and create a new file with a running session index in the name.

However the user must ensure each instance of `qudi` is running with a different namespace (and remote modules) socket server address configured in order to avoid conflicts.

## How Has This Been Tested?
Dummy modules windows 10 Pro 21H2 (build 19044.2130)

## Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
