### PR TITLE
New utility descriptor `CheckedAttribute`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,9 +9,8 @@ None
 None
 
 ### New Features
-- Added utility descriptor objects `CheckedAttribute` and `TypedAttribute` to 
-`qudi.util.constraints`. Can be used to perform customized automatic sanity checking on attribute 
-value assignments.
+- Added utility descriptor objects to new module `qudi.util.descriptors`. Can be used to 
+facilitate smart instance attribute handling. 
 
 ### Other
 None

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,8 +9,9 @@ None
 None
 
 ### New Features
-- Added utility descriptor object `qudi.util.constraints.CheckedAttribute`. Can be used to perform 
-customized automatic sanity checking on attribute value assignments.
+- Added utility descriptor objects `CheckedAttribute` and `TypedAttribute` to 
+`qudi.util.constraints`. Can be used to perform customized automatic sanity checking on attribute 
+value assignments.
 
 ### Other
 None

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,8 @@ None
 None
 
 ### New Features
-None
+- Added utility descriptor object `qudi.util.constraints.CheckedAttribute`. Can be used to perform 
+customized automatic sanity checking on attribute value assignments.
 
 ### Other
 None

--- a/src/qudi/util/constraints.py
+++ b/src/qudi/util/constraints.py
@@ -19,7 +19,7 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
-__all__ = ['ScalarConstraint', 'CheckedAttribute']
+__all__ = ['ScalarConstraint', 'CheckedAttribute', 'TypedAttribute']
 
 from inspect import isclass, signature
 from typing import Union, Optional, Tuple, Callable, Any, Type, Iterable

--- a/src/qudi/util/constraints.py
+++ b/src/qudi/util/constraints.py
@@ -183,13 +183,13 @@ class CheckedAttribute:
             my_number = CheckedVariable([int, float])
             my_custom = CheckedVariable([str], validators=[custom_validate])
             def __init__(self):
-                my_string = 'I am a test string'
-                my_number = 42
-                my_custom = 'foo is the beginning and it must end on bar'
+                self.my_string = 'I am a test string'
+                self.my_number = 42
+                self.my_custom = 'foo is the beginning and it must end on bar'
                 # Following assignments would raise
-                # my_string = 42
-                # my_number = None
-                # my_custom = 'It is a string but it fails custom validator'
+                # self.my_string = 42
+                # self.my_number = None
+                # self.my_custom = 'It is a string but it fails custom validator'
     """
     def __init__(self,
                  valid_types: Optional[Iterable[Type]] = None,

--- a/src/qudi/util/constraints.py
+++ b/src/qudi/util/constraints.py
@@ -179,9 +179,9 @@ class CheckedAttribute:
                 raise ValueError('String must start with "foo" and end with "bar"')
 
         class Test:
-            my_string = CheckedVariable([str])
-            my_number = CheckedVariable([int, float])
-            my_custom = CheckedVariable([str], validators=[custom_validate])
+            my_string = CheckedAttribute([str])
+            my_number = CheckedAttribute([int, float])
+            my_custom = CheckedAttribute([str], validators=[custom_validate])
             def __init__(self):
                 self.my_string = 'I am a test string'
                 self.my_number = 42

--- a/src/qudi/util/descriptors.py
+++ b/src/qudi/util/descriptors.py
@@ -1,0 +1,261 @@
+# -*- coding: utf-8 -*-
+"""
+Descriptor objects that can be used to simplify common tasks related to object attributes.
+
+Copyright (c) 2023, the qudi developers. See the AUTHORS.md file at the top-level directory of this
+distribution and on <https://github.com/Ulm-IQO/qudi-core/>
+
+This file is part of qudi.
+
+Qudi is free software: you can redistribute it and/or modify it under the terms of
+the GNU Lesser General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+Qudi is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with qudi.
+If not, see <https://www.gnu.org/licenses/>.
+"""
+
+__all__ = ['BaseAttribute', 'DefaultAttribute', 'ReadOnlyAttribute', 'TypedAttribute',
+           'CheckedAttribute', 'DefaultMixin', 'ReadOnlyMixin', 'TypedMixin', 'ValidateMixin']
+
+from typing import Any, Optional, Iterable, Type, Callable, Union
+from inspect import isclass, signature
+
+
+class DefaultMixin:
+    """ Mixin for BaseAttribute introducing optional default value behaviour in __get__.
+    If no default value is specified, fall back to raising AttributeError.
+    """
+    _no_default = object()  # unique placeholder
+
+    def __init__(self, default: Optional[Any] = _no_default, **kwargs):
+        super().__init__(**kwargs)
+        self.default = default
+
+    def __get__(self, instance, owner):
+        try:
+            return super().__get__(instance, owner)
+        except AttributeError:
+            if self.default is self._no_default:
+                raise
+            return self.default
+
+    def __delete__(self, instance):
+        try:
+            super().__delete__(instance)
+        except AttributeError:
+            pass
+
+
+class ReadOnlyMixin:
+    """ Mixin for BaseAttribute introducing read-only access """
+    def __delete__(self, instance):
+        raise AttributeError('Read-only attribute can not be deleted')
+
+    def __set__(self, instance, value):
+        raise AttributeError('Read-only attribute can not be overwritten')
+
+    def set_value(self, instance: object, value: Any) -> None:
+        super().__set__(instance, value)
+
+
+class TypedMixin:
+    """ Mixin for BaseAttribute introducing optional type checking via isinstance builtin """
+    def __init__(self, valid_types: Optional[Iterable[Type]] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.valid_types = None if valid_types is None else tuple(valid_types)
+        if self.valid_types and not all(isclass(typ) for typ in self.valid_types):
+            raise TypeError('valid_types must be iterable of types (classes)')
+
+    def __set__(self, instance, value):
+        self.check_type(value)
+        super().__set__(instance, value)
+
+    def check_type(self, value: Any) -> None:
+        if self.valid_types and not isinstance(value, self.valid_types):
+            raise TypeError(
+                f'Value must be of type(s) [{", ".join(t.__name__ for t in self.valid_types)}]'
+            )
+
+
+class ValidateMixin:
+    """ Mixin for BaseAttribute introducing optional validation via registering static and/or
+    bound validator methods.
+    Bound methods are best registered via the "validator" decorator (cooperative with
+    staticmethod/classmethod decorator)
+    """
+    def __init__(self,
+                 static_validators: Optional[Iterable[Callable[[Any], None]]] = None,
+                 **kwargs):
+        super().__init__(**kwargs)
+        self.static_validators = list() if static_validators is None else list(static_validators)
+        self.bound_validators = list()
+        if not all(callable(val) for val in self.static_validators):
+            raise TypeError('static_validators must be iterable of callables')
+
+    def __set__(self, instance, value):
+        self.validate(value, instance)
+        super().__set__(instance, value)
+
+    def validator(self, func: Union[Callable[[Any, Any], None], Callable[[Any], None]]) -> Callable:
+        """ Decorator to register either a static or bound validator """
+        func_obj = func if callable(func) else func.__func__
+        if len(signature(func_obj).parameters) == 1:
+            self.static_validators.append(func_obj)
+        elif func_obj.__name__.startswith('__') and func_obj.__qualname__:
+            cls_name = func_obj.__qualname__.rsplit('.', 1)[0]
+            self.bound_validators.append(f'_{cls_name}{func_obj.__name__}')
+        else:
+            self.bound_validators.append(func_obj.__name__)
+        return func
+
+    def validate(self, value: Any, instance: Optional[Any] = None) -> None:
+        try:
+            for func in self.static_validators:
+                func(value)
+            for func_name in self.bound_validators:
+                try:
+                    func = getattr(instance, func_name)
+                except AttributeError:
+                    raise AttributeError(
+                        f'Registered bound validator "{func_name}" not found in {instance}'
+                    ) from None
+                func(value)
+        except Exception as err:
+            raise ValueError(f'Value "{value}" did not pass validation') from err
+
+
+class BaseAttribute:
+    """ Base descriptor class implementing trivial get/set/delete behaviour for an instance
+    attribute.
+    """
+    def __init__(self):
+        super().__init__()
+        self.attr_name = None
+
+    def __set_name__(self, owner, name):
+        self.attr_name = name
+
+    def __get__(self, instance, owner):
+        try:
+            return instance.__dict__[self.attr_name]
+        except KeyError:
+            raise AttributeError(self.attr_name) from None
+        except AttributeError:
+            return self
+
+    def __delete__(self, instance):
+        try:
+            del instance.__dict__[self.attr_name]
+        except KeyError:
+            raise AttributeError(self.attr_name) from None
+
+    def __set__(self, instance, value):
+        instance.__dict__[self.attr_name] = value
+
+
+class DefaultAttribute(DefaultMixin, BaseAttribute):
+    """ Attribute that can be given a default value which is used if not explicitly initialized by
+    the instance.
+
+    Example usage:
+
+        class Test:
+            variable_a = DefaultAttribute(42)
+            variable_b = DefaultAttribute()
+            def __init__(self):
+                self.variable_b = self.variable_a - 42
+                assert self.variable_a == 42
+                assert self.variable_b == 0
+    """
+    def __init__(self, default: Optional[Any] = DefaultMixin._no_default):
+        super().__init__(default=default)
+
+
+class ReadOnlyAttribute(ReadOnlyMixin, DefaultAttribute):
+    """ Extension of DefaultAttribute to be read-only. A non-default value can be set by calling
+    "set_value(instance, value)" on the descriptor instance.
+
+    Example usage:
+
+        class Test:
+            variable_a = ReadOnlyAttribute(42)
+            variable_b = ReadOnlyAttribute()
+            def __init__(self):
+                self.__class__.variable_b.set_value(self, self.variable_a - 42)
+                assert self.variable_a == 42
+                assert self.variable_b == 0
+                # The following would raise an AttributeError
+                # self.variable_b = 0
+    """
+    pass
+
+
+class TypedAttribute(TypedMixin, DefaultAttribute):
+    """ Extension of DefaultAttribute including type checking via isinstance. A given default
+    value is not type-checked.
+
+    Example usage:
+
+        class Test:
+            variable_a = TypedAttribute([int, float])
+            variable_b = TypedAttribute([str], None)
+            def __init__(self):
+                assert self.variable_b is None
+                self.variable_a = 42
+                self.variable_b = 'hello world'
+                assert self.variable_a == 42
+                assert self.variable_b == 'hello world'
+                # The following would raise TypeError
+                # self.variable_a = self.variable_b = None
+    """
+    def __init__(self,
+                 valid_types: Optional[Iterable[Type]] = None,
+                 default: Optional[Any] = DefaultAttribute._no_default):
+        super().__init__(valid_types=valid_types, default=default)
+
+
+class CheckedAttribute(TypedMixin, ValidateMixin, DefaultAttribute):
+    """ Extension of DefaultAttribute including optional validation via static or bound validator
+    methods as well as optional type checking via "isinstance".
+    A given default value is not validated. Type checking is performed before validation.
+    Register bound validator methods via the CheckedAttribute.validator decorator. This decorator
+    can be combined with classmethod/staticmethod decorators in any order.
+
+    Example usage:
+
+        def my_static_validator(value):
+            if not (0 <= value <= 100):
+                raise ValueError('Value must be number between 0 and 100')
+
+        class Test:
+            variable_a = CheckedAttribute([my_static_validator], [int, float], 0)
+            variable_b = CheckedAttribute(valid_types=[str])
+            _valid_strings = ['A', 'B', 'C']
+
+            def __init__(self):
+                self.variable_a = 66.7
+                self.variable_b = 'B'
+                assert self.variable_a == 66.7
+                assert self.variable_b == 'B'
+                # The following would raise ValueError
+                # self.variable_a = 101
+                # self.variable_b = 'D'
+
+            @variable_b.validator
+            @classmethod
+            def _validate_variable_b(cls, value):
+                if value not in cls._valid_strings:
+                    raise ValueError(f'Invalid string. Valid strings are: {cls._valid_strings}')
+    """
+    def __init__(self,
+                 static_validators: Optional[Iterable[Callable[[Any], None]]] = None,
+                 valid_types: Optional[Iterable[Type]] = None,
+                 default: Optional[Any] = DefaultAttribute._no_default):
+        super().__init__(static_validators=static_validators,
+                         valid_types=valid_types,
+                         default=default)


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
This PR aims to add a new convenience feature to `qudi-core`.
The new descriptor object `qudi.util.constraints.CheckedAttribute` can be used to perform automatic sanity checking upon setting an objects attribute.
Sanity checks can be performed by providing validator callables to the descriptor object.
If a bound method should be used as validator, there is a convenient decorator `CheckedAttribute.validator` that can be used (also collaborative with `@staticmethod` or `@classmethod`).
For easier type checking via `isinstance` builtin, there is a specialized subclass `qudi.util.constraints.TypedAttribute` that can be initialized with valid types in addition to validator callables. These type checks are performed before the provided validator are called.

Also extended `qudi.util.constraints.ScalarConstraint` in a non-breaking way to provide more functionality.

## Motivation and Context
Example usage:
```python
from qudi.util.constraints import CheckedAttribute, TypedAttribute

def validate_number(value):
    if not isinstance(value, (float, int)) or not (0 <= value <= 100):
        raise ValueError('Value must be number between 0 and 100')

def validate_string(value):
    if len(value) > 100:
        raise ValueError('String must not be larger than 100 characters')

class Test:
    my_custom = CheckedAttribute([validate_number])
    my_string = TypedAttribute([str], static_validators=[validate_string])
    my_number = TypedAttribute([int, float])
    
    def __init__(self):
        self._must_start_with = 'I am'
        self.my_string = 'I am a valid string'
        self.my_number = 42
        self.my_custom = 50
        # Following assignments would raise:
        # self.my_string = 'I am too long' + '!' * 100
        # self.my_number = None
        # self.my_custom = 101

    @my_string.validator
    def _validate_my_string(self, value: str) -> None:
        if not value.startswith(self._must_start_with):
            raise ValueError(f'my_string must start with "{self._must_start_with}"')
```

## How Has This Been Tested?
Standalone feature. Has been tested in a small test notebook.

## Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
