### PR TITLE
DictTableModel bugfix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,8 @@
 None
 
 ### Bugfixes
-None
+- Fixed a bug that caused `qudi.util.models.DictTableModel` to raise `IndexError` when used in a 
+`ListView` and/or when data at index zero is requested.
 
 ### New Features
 - Added helper functions in util/linear_transform.py to allow transformations (rotations and shifts) using the afﬁne transformation matrix formalism.

--- a/src/qudi/util/models.py
+++ b/src/qudi/util/models.py
@@ -83,14 +83,12 @@ class DictTableModel(QtCore.QAbstractTableModel):
         """ Get a dict key by index number """
         with self._lock:
             it = iter(self._storage)
-            key = None
             try:
-                for i in range(n):
+                for _ in range(n+1):
                     key = next(it)
             except StopIteration:
-                pass
-            if key is None:
-                raise IndexError
+                raise IndexError(f'Index {n:d} out of bounds for table model with '
+                                 f'{len(self._storage):d} rows') from None
             return key
 
     def get_index_by_key(self, key: Any) -> int:


### PR DESCRIPTION
## Description
Bugfix in the `qudi.util.models.DictTableModel.get_key_by_index` method. Index was off-by-one. Also improved `IndexError` message.

## Motivation and Context
Resolves #70 

## How Has This Been Tested?
Load config with one or more modules configured as `allow_remote: True` and click in manager GUI `View -> Show remote`

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
