### PR TITLE
Fitmodel loading bugfix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,9 @@
 None
 
 ### Bugfixes
-None
+- Fixes a bug where all fit configurations for a fit model/container fail to load upon activation 
+of a module because the fit model saved in AppData is no longer available. Throws a warning now 
+instead and ignores the respective fit configuration.
 
 ### New Features
 - Added helper functions in util/linear_transform.py to allow transformations (rotations and shifts) using the afﬁne transformation matrix formalism.

--- a/src/qudi/util/datafitting.py
+++ b/src/qudi/util/datafitting.py
@@ -265,7 +265,12 @@ class FitConfigurationsModel(QtCore.QAbstractListModel):
 
         @param iterable configs: Iterable of FitConfiguration dict representations
         """
-        config_objects = [FitConfiguration.from_dict(cfg) for cfg in configs]
+        config_objects = list()
+        for cfg in configs:
+            try:
+                config_objects.append(FitConfiguration.from_dict(cfg))
+            except:
+                _log.warning(f'Unable to load fit configuration:\n{cfg}')
         self.beginResetModel()
         self._fit_configurations = config_objects
         self.endResetModel()

--- a/src/qudi/util/datafitting.py
+++ b/src/qudi/util/datafitting.py
@@ -241,7 +241,6 @@ class FitConfigurationsModel(QtCore.QAbstractListModel):
                       value=value_tuple[1],
                       min=value_tuple[2],
                       max=value_tuple[3])
-            print('setData:', params)
             config.estimator = None if not value[0] else value[0]
             config.custom_parameters = None if not params else params
             self.dataChanged.emit(self.createIndex(index.row(), 0),

--- a/src/qudi/util/units.py
+++ b/src/qudi/util/units.py
@@ -193,9 +193,9 @@ def create_formatted_output(param_dict, num_sig_digits=5):
                 sc_fact, unit_prefix = fn.siScale(param_dict[entry]['value'])
                 str_val = '{0:.{1}e}'.format(
                     param_dict[entry]['value'], num_sig_digits - 1)
-                if np.isnan(np.float(str_val)):
+                if np.isnan(float(str_val)):
                     value = np.NAN
-                elif np.isinf(np.float(str_val)):
+                elif np.isinf(float(str_val)):
                     value = np.inf
                 else:
                     value = float('{0:.{1}e}'.format(

--- a/src/qudi/util/widgets/fitting.py
+++ b/src/qudi/util/widgets/fitting.py
@@ -372,7 +372,6 @@ class _FitConfigurationItemDelegate(QtWidgets.QStyledItemDelegate):
 
     def createEditor(self, parent, option, index):
         if index.isValid():
-            print('createEditor:', index.row())
             editor = _FitConfigPanel(parent=parent, fit_config=index.data(QtCore.Qt.DisplayRole))
             editor.setGeometry(option.rect)
             editor.sigConfigurationRemovedClicked.connect(self.parent().remove_config_clicked)
@@ -384,7 +383,6 @@ class _FitConfigurationItemDelegate(QtWidgets.QStyledItemDelegate):
             editor.update_fit_config(index.data(QtCore.Qt.DisplayRole))
 
     def setModelData(self, editor, model, index):
-        print('setModelData:', index.row())
         data = (editor.estimator, editor.custom_parameters)
         model.setData(index, data)
 
@@ -406,7 +404,6 @@ class _FitConfigurationItemDelegate(QtWidgets.QStyledItemDelegate):
         painter.restore()
 
     def destroyEditor(self, editor, index):
-        print('destroyEditor:', index.row())
         editor.sigConfigurationRemovedClicked.disconnect()
         self.setModelData(editor, index.model(), index)
         return super().destroyEditor(editor, index)


### PR DESCRIPTION
## Description
Fixes a bug where all fit configurations for a fit model/container fail to load upon activation of a module because the fit model saved in AppData is no longer available. Throws a warning now instead and ignores the respective fit configuration.

## Motivation and Context
Resolves #59 
Also fixes a deprecated usage of the `numpy.float()` constructor.

## How Has This Been Tested?
- Configured a custom fit in ODMR toolchain 
- Closed qudi
- Deleted respective fit model from code
- Started qudi and ODMR toolchain

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
