### PR TITLE
Fit parameters as dict

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,9 @@ None
 None
 
 ### Other
-None
+- Fine-tuning of string output of fit results from qudi.util.units.create_formatted_output(): Failed fits should provide
+  error= np.nan. Fixed parameters are marked as such. Brackets introduced, eg. (2.67 ± 0.01) GHz.
+
 
 
 ## Version 1.3.0

--- a/src/qudi/util/datafitting.py
+++ b/src/qudi/util/datafitting.py
@@ -342,10 +342,13 @@ class FitContainer(QtCore.QObject):
             parameters_units = dict()
         parameters_to_format = dict()
         for name, param in fit_result.params.items():
-            if not param.vary:
-                continue
+
+            param_fixed = False if param.vary else True
+            stderr = param.stderr if not param_fixed else None
+            stderr = np.nan if not param_fixed and stderr is None else stderr
+
             parameters_to_format[name] = {'value': param.value,
-                                          'error': param.stderr,
+                                          'error': stderr,
                                           'unit': parameters_units.get(name, '')}
         return create_formatted_output(parameters_to_format)
 

--- a/src/qudi/util/datafitting.py
+++ b/src/qudi/util/datafitting.py
@@ -350,7 +350,7 @@ class FitContainer(QtCore.QObject):
         return create_formatted_output(parameters_to_format)
 
     @staticmethod
-    def dict_result(fit_result, keys=['value', 'stderr', 'min', 'max']):
+    def dict_result(fit_result, keys=['value', 'stderr', 'min', 'max'], debug_use_new=True):
         export_keys = keys
         fitparams = fit_result.result.params
         export_dict = {'model': fit_result.model.name}
@@ -358,5 +358,20 @@ class FitContainer(QtCore.QObject):
         for key, res in fitparams.items():
             dict_i = {key: getattr(res, key) for key in export_keys}
             export_dict[key] = dict_i
+
+        if debug_use_new:
+            # make use of ModelResult.summary(), introduced in lmfit-1.2.0
+            export_dict = {'model': fit_result.model.name}
+
+            # tuple order according to lmfit docs
+            tuple_keys = ['name', 'value', 'vary', 'expr', 'min', 'max', 'brute_step',
+                          'stderr', 'correl', 'init_value', 'user_data']
+            fitparams = fit_result.summary()['params']
+
+            for param in fitparams:
+                param_dict = {tuple_keys[i]: param[i] for i in range(len(tuple_keys))}
+                param_name = param_dict['name']
+                param_dict = {key: param_dict[key] for key in param_dict.keys() if key in export_keys}
+                export_dict[param_name] = param_dict
 
         return export_dict

--- a/src/qudi/util/datafitting.py
+++ b/src/qudi/util/datafitting.py
@@ -350,28 +350,21 @@ class FitContainer(QtCore.QObject):
         return create_formatted_output(parameters_to_format)
 
     @staticmethod
-    def dict_result(fit_result, keys=['value', 'stderr', 'min', 'max'], debug_use_new=True):
+    def dict_result(fit_result, keys=['value', 'stderr'], parameters_units=None):
         export_keys = keys
+        export_dict = {}
+
+        if fit_result is None:
+            return export_dict
+        if parameters_units is None:
+            parameters_units = dict()
+
         fitparams = fit_result.result.params
         export_dict = {'model': fit_result.model.name}
 
         for key, res in fitparams.items():
             dict_i = {key: getattr(res, key) for key in export_keys}
+            dict_i['unit'] = parameters_units.get(key, '')
             export_dict[key] = dict_i
-
-        if debug_use_new:
-            # make use of ModelResult.summary(), introduced in lmfit-1.2.0
-            export_dict = {'model': fit_result.model.name}
-
-            # tuple order according to lmfit docs
-            tuple_keys = ['name', 'value', 'vary', 'expr', 'min', 'max', 'brute_step',
-                          'stderr', 'correl', 'init_value', 'user_data']
-            fitparams = fit_result.summary()['params']
-
-            for param in fitparams:
-                param_dict = {tuple_keys[i]: param[i] for i in range(len(tuple_keys))}
-                param_name = param_dict['name']
-                param_dict = {key: param_dict[key] for key in param_dict.keys() if key in export_keys}
-                export_dict[param_name] = param_dict
 
         return export_dict

--- a/src/qudi/util/datafitting.py
+++ b/src/qudi/util/datafitting.py
@@ -29,6 +29,7 @@ import inspect
 import lmfit
 import numpy as np
 from PySide2 import QtCore
+from typing import Iterable, Optional, Mapping, Union
 
 import qudi.util.fit_models as _fit_models_ns
 from qudi.util.mutex import Mutex
@@ -335,30 +336,30 @@ class FitContainer(QtCore.QObject):
             return '', None
 
     @staticmethod
-    def formatted_result(fit_result, parameters_units=None):
+    def formatted_result(fit_result: Union[None, lmfit.model.ModelResult],
+                         parameters_units: Optional[Mapping[str, str]] = None) -> str:
         if fit_result is None:
             return ''
         if parameters_units is None:
             parameters_units = dict()
+
         parameters_to_format = dict()
         for name, param in fit_result.params.items():
-
-            param_fixed = False if param.vary else True
-            stderr = param.stderr if not param_fixed else None
-            stderr = np.nan if not param_fixed and stderr is None else stderr
+            stderr = param.stderr if param.vary else None
+            stderr = np.nan if param.vary and stderr is None else stderr
 
             parameters_to_format[name] = {'value': param.value,
                                           'error': stderr,
                                           'unit': parameters_units.get(name, '')}
+
         return create_formatted_output(parameters_to_format)
 
     @staticmethod
-    def dict_result(fit_result, keys=['value', 'stderr'], parameters_units=None):
-        export_keys = keys
-        export_dict = {}
-
+    def dict_result(fit_result: Union[None, lmfit.model.ModelResult],
+                    parameters_units: Optional[Mapping[str, str]] = None,
+                    export_keys: Optional[Iterable[str]] = ('value', 'stderr')) -> dict:
         if fit_result is None:
-            return export_dict
+            return dict()
         if parameters_units is None:
             parameters_units = dict()
 

--- a/src/qudi/util/datafitting.py
+++ b/src/qudi/util/datafitting.py
@@ -348,3 +348,15 @@ class FitContainer(QtCore.QObject):
                                           'error': param.stderr,
                                           'unit': parameters_units.get(name, '')}
         return create_formatted_output(parameters_to_format)
+
+    @staticmethod
+    def dict_result(fit_result, keys=['value', 'stderr', 'min', 'max']):
+        export_keys = keys
+        fitparams = fit_result.result.params
+        export_dict = {'model': fit_result.model.name}
+
+        for key, res in fitparams.items():
+            dict_i = {key: getattr(res, key) for key in export_keys}
+            export_dict[key] = dict_i
+
+        return export_dict

--- a/src/qudi/util/units.py
+++ b/src/qudi/util/units.py
@@ -193,9 +193,9 @@ def create_formatted_output(param_dict, num_sig_digits=5):
                 sc_fact, unit_prefix = fn.siScale(param_dict[entry]['value'])
                 str_val = '{0:.{1}e}'.format(
                     param_dict[entry]['value'], num_sig_digits - 1)
-                if np.isnan(np.float(str_val)):
+                if np.isnan(np.float64(str_val)):
                     value = np.NAN
-                elif np.isinf(np.float(str_val)):
+                elif np.isinf(np.float64(str_val)):
                     value = np.inf
                 else:
                     value = float('{0:.{1}e}'.format(
@@ -217,7 +217,7 @@ def create_formatted_output(param_dict, num_sig_digits=5):
             output_str += '{0}: '.format(entry) + fn.siFormat(param_dict[entry]['value'],
                                                               precision=num_sig_digits,
                                                               suffix=param_dict[entry][
-                                                                  'unit']) + '\n'
+                                                                  'unit']) + ' (fixed) \n'
     return output_str
 
 

--- a/src/qudi/util/units.py
+++ b/src/qudi/util/units.py
@@ -207,12 +207,12 @@ def create_formatted_output(param_dict, num_sig_digits=5):
                 # range, rather then from the value 1000 to 1, which is
                 # default.
                 sc_fact, unit_prefix = fn.siScale(error * 10)
-            output_str += '{0}: {1} \u00B1 {2} {3}{4} \n'.format(entry, round(value * sc_fact,
-                                                                              num_sig_digits - 1),
-                                                                 round(error * sc_fact,
-                                                                       num_sig_digits - 1),
-                                                                 unit_prefix,
-                                                                 param_dict[entry]['unit'])
+            output_str += '{0}: ({1} \u00B1 {2}) {3}{4} \n'.format(entry, round(value * sc_fact,
+                                                                                num_sig_digits - 1),
+                                                                   round(error * sc_fact,
+                                                                         num_sig_digits - 1),
+                                                                   unit_prefix,
+                                                                   param_dict[entry]['unit'])
         else:
             output_str += '{0}: '.format(entry) + fn.siFormat(param_dict[entry]['value'],
                                                               precision=num_sig_digits,


### PR DESCRIPTION
This PR adds an additional wrapper to the fitting module that returns fit parameters as a dict.
iqo-modules uses this dict to add the fit result to the save meta data. 

Addtionally, I changed the behavior in formatted_result() when handling fixed fit parameters.
These are now marked in the result string ("fixed") instead of silently dropped.
However, this change requires fit results that failed to input stderr=np.nan to the fit formatter, instead of lmfit's default behavior (stderr=None).

## How Has This Been Tested?
on dummy


## Types of changes
- [ ] Bug fix
- [x] New feature
- [x] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [x] All changed Jupyter notebooks have been stripped of their output cells.
