### PR TITLE
Backward compatiblity bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 .DS_store
 
 # Local config directories
-/*.egg-info
+*.egg-info
 
 # Simulated Subversion default ignores end here
 # The contents of the svn:ignore property on the branch root.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ None
 
 ### Bugfixes
 - Fixed a bug where `TextDataStorage` would load one line of data less than it saves.
+- Updated the import in `qudi.util.units` to fix a bug concerning a new version of scipy,
+since windowing functions have been moved from scipy.signal to scipy.signal.windows.
+- In `qudi.util.widgets.plotting.interactive_curve.InteractiveCurvesWidget`, the plot widget was made into 
+a private attribute. Added a getter method to access it.
 
 ### New Features
 None

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@
 None
 
 ### Bugfixes
-None
+- Fixed a bug where `TextDataStorage` would load one line of data less than it saves.
 
 ### New Features
 None

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ None
 
 ### Bugfixes
 - Fixed a bug where `TextDataStorage` would load one line of data less than it saves.
-- Updated the import in `qudi.util.units` to fix a bug concerning a new version of scipy,
+- Updated the import in `qudi.util.math` to fix a bug concerning a new version of scipy,
 since windowing functions have been moved from scipy.signal to scipy.signal.windows.
 - In `qudi.util.widgets.plotting.interactive_curve.InteractiveCurvesWidget`, the plot widget was made into 
 a private attribute. Added a getter method to access it.

--- a/src/qudi/core/modulemanager.py
+++ b/src/qudi/core/modulemanager.py
@@ -29,7 +29,7 @@ from typing import FrozenSet, Iterable
 from functools import partial
 from PySide2 import QtCore
 
-from qudi.util.mutex import RecursiveMutex   # provides access serialization between threads
+from qudi.util.mutex import RecursiveMutex  # provides access serialization between threads
 from qudi.core.logger import get_logger
 from qudi.core.servers import get_remote_module_instance
 from qudi.core.module import Base, get_module_app_data_path
@@ -624,7 +624,6 @@ class ManagedModule(QtCore.QObject):
                     self._instance.module_state.deactivate()
                 except fysom.Canceled:
                     pass
-            QtCore.QCoreApplication.instance().processEvents()  # ToDo: Is this still needed?
 
             # Disconnect modules from this module
             self._disconnect()

--- a/src/qudi/util/datastorage.py
+++ b/src/qudi/util/datastorage.py
@@ -636,7 +636,7 @@ class TextDataStorage(DataStorageBase):
                                  dtype=dtype,
                                  comments=general['comments'],
                                  delimiter=general['delimiter'],
-                                 skip_header=header_lines + 2)
+                                 skip_header=header_lines + 1)
         except UnicodeError as err:
             raise ValueError(f'Loading data from file "{file_path}" failed. The file you are '
                              f'trying to load is most likely no unicode textfile.') from err

--- a/src/qudi/util/math.py
+++ b/src/qudi/util/math.py
@@ -22,7 +22,7 @@ If not, see <https://www.gnu.org/licenses/>.
 __all__ = ('compute_ft', 'ft_windows')
 
 import numpy as np
-from scipy import signal
+from scipy.signal import windows
 
 # Available windows to be applied on signal data before FT.
 # To find out the amplitude normalization factor check either the scipy implementation on
@@ -32,17 +32,17 @@ from scipy import signal
 #     MM=1000000  # choose a big number
 #     print(sum(signal.hanning(MM))/MM)
 ft_windows = {'none': {'func': np.ones, 'ampl_norm': 1.0},
-              'hamming': {'func': signal.hamming, 'ampl_norm': 1.0/0.54},
-              'hann': {'func': signal.hann, 'ampl_norm': 1.0/0.5},
-              'blackman': {'func': signal.blackman, 'ampl_norm': 1.0/0.42},
-              'triang': {'func': signal.triang, 'ampl_norm': 1.0/0.5},
-              'flattop': {'func': signal.flattop, 'ampl_norm': 1.0/0.2156},
-              'bartlett': {'func': signal.bartlett, 'ampl_norm': 1.0/0.5},
-              'parzen': {'func': signal.parzen, 'ampl_norm': 1.0/0.375},
-              'bohman': {'func': signal.bohman, 'ampl_norm': 1.0/0.4052847},
-              'blackmanharris': {'func': signal.blackmanharris, 'ampl_norm': 1.0/0.35875},
-              'nuttall': {'func': signal.nuttall, 'ampl_norm': 1.0/0.3635819},
-              'barthann': {'func': signal.barthann, 'ampl_norm': 1.0/0.5}
+              'hamming': {'func': windows.hamming, 'ampl_norm': 1.0/0.54},
+              'hann': {'func': windows.hann, 'ampl_norm': 1.0/0.5},
+              'blackman': {'func': windows.blackman, 'ampl_norm': 1.0/0.42},
+              'triang': {'func': windows.triang, 'ampl_norm': 1.0/0.5},
+              'flattop': {'func': windows.flattop, 'ampl_norm': 1.0/0.2156},
+              'bartlett': {'func': windows.bartlett, 'ampl_norm': 1.0/0.5},
+              'parzen': {'func': windows.parzen, 'ampl_norm': 1.0/0.375},
+              'bohman': {'func': windows.bohman, 'ampl_norm': 1.0/0.4052847},
+              'blackmanharris': {'func': windows.blackmanharris, 'ampl_norm': 1.0/0.35875},
+              'nuttall': {'func': windows.nuttall, 'ampl_norm': 1.0/0.3635819},
+              'barthann': {'func': windows.barthann, 'ampl_norm': 1.0/0.5}
               }
 
 

--- a/src/qudi/util/units.py
+++ b/src/qudi/util/units.py
@@ -202,17 +202,13 @@ def create_formatted_output(param_dict, num_sig_digits=5):
                         param_dict[entry]['value'], num_sig_digits - 1))
 
             else:
-                # the factor 10 moves the displayed digit by one to the right,
-                # so that the values from 100 to 0.1 are displayed within one
-                # range, rather then from the value 1000 to 1, which is
-                # default.
-                sc_fact, unit_prefix = fn.siScale(error * 10)
-            output_str += '{0}: ({1} \u00B1 {2}) {3}{4} \n'.format(entry, round(value * sc_fact,
-                                                                                num_sig_digits - 1),
-                                                                   round(error * sc_fact,
-                                                                         num_sig_digits - 1),
-                                                                   unit_prefix,
-                                                                   param_dict[entry]['unit'])
+                sc_fact, unit_prefix = fn.siScale(value)
+            output_str += '{0}: {1} \u00B1 {2} {3}{4} \n'.format(entry, round(value * sc_fact,
+                                                                              num_sig_digits - 1),
+                                                                 round(error * sc_fact,
+                                                                       num_sig_digits - 1),
+                                                                 unit_prefix,
+                                                                 param_dict[entry]['unit'])
         else:
             output_str += '{0}: '.format(entry) + fn.siFormat(param_dict[entry]['value'],
                                                               precision=num_sig_digits,

--- a/src/qudi/util/widgets/plotting/interactive_curve.py
+++ b/src/qudi/util/widgets/plotting/interactive_curve.py
@@ -489,6 +489,10 @@ class InteractiveCurvesWidget(QtWidgets.QWidget):
             return self._get_valid_generic_name(index + 1)
         return name
 
+    @property
+    def plot_widget(self) -> PlotWidget:
+        return self._plot_widget
+
     def plot(self, name: Optional[str] = None, **kwargs) -> str:
         # Delete old plot if present
         if name is None:


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->
Minor changes to fix backwards compatiblity issues.
## Description
<!--- Describe your changes in detail -->
In util/math, the old version of scipy contained windowing functions in scipy.signal, but no they are in scipy.signal.windows. Updated the code accordingly.
In InteractiveCurvesWidget, the plot widget is now a private attribute. Added a getter method to access it.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows old modules to work in the new version of qudi.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested using the PShell analysis logic and loading the live acquisition GUI.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
