### PR TITLE
[Hotfix] Util/maths broken for scipy > 1.12.0

### DIFF
--- a/src/qudi/util/math.py
+++ b/src/qudi/util/math.py
@@ -22,7 +22,7 @@ If not, see <https://www.gnu.org/licenses/>.
 __all__ = ('compute_ft', 'ft_windows')
 
 import numpy as np
-from scipy import signal
+from scipy.signal import windows as window_func
 
 # Available windows to be applied on signal data before FT.
 # To find out the amplitude normalization factor check either the scipy implementation on
@@ -32,17 +32,17 @@ from scipy import signal
 #     MM=1000000  # choose a big number
 #     print(sum(signal.hanning(MM))/MM)
 ft_windows = {'none': {'func': np.ones, 'ampl_norm': 1.0},
-              'hamming': {'func': signal.hamming, 'ampl_norm': 1.0/0.54},
-              'hann': {'func': signal.hann, 'ampl_norm': 1.0/0.5},
-              'blackman': {'func': signal.blackman, 'ampl_norm': 1.0/0.42},
-              'triang': {'func': signal.triang, 'ampl_norm': 1.0/0.5},
-              'flattop': {'func': signal.flattop, 'ampl_norm': 1.0/0.2156},
-              'bartlett': {'func': signal.bartlett, 'ampl_norm': 1.0/0.5},
-              'parzen': {'func': signal.parzen, 'ampl_norm': 1.0/0.375},
-              'bohman': {'func': signal.bohman, 'ampl_norm': 1.0/0.4052847},
-              'blackmanharris': {'func': signal.blackmanharris, 'ampl_norm': 1.0/0.35875},
-              'nuttall': {'func': signal.nuttall, 'ampl_norm': 1.0/0.3635819},
-              'barthann': {'func': signal.barthann, 'ampl_norm': 1.0/0.5}
+              'hamming': {'func': window_func.hamming, 'ampl_norm': 1.0/0.54},
+              'hann': {'func': window_func.hann, 'ampl_norm': 1.0/0.5},
+              'blackman': {'func': window_func.blackman, 'ampl_norm': 1.0/0.42},
+              'triang': {'func': window_func.triang, 'ampl_norm': 1.0/0.5},
+              'flattop': {'func': window_func.flattop, 'ampl_norm': 1.0/0.2156},
+              'bartlett': {'func': window_func.bartlett, 'ampl_norm': 1.0/0.5},
+              'parzen': {'func': window_func.parzen, 'ampl_norm': 1.0/0.375},
+              'bohman': {'func': window_func.bohman, 'ampl_norm': 1.0/0.4052847},
+              'blackmanharris': {'func': window_func.blackmanharris, 'ampl_norm': 1.0/0.35875},
+              'nuttall': {'func': window_func.nuttall, 'ampl_norm': 1.0/0.3635819},
+              'barthann': {'func': window_func.barthann, 'ampl_norm': 1.0/0.5}
               }
 
 


### PR DESCRIPTION
Using the windows functions from scipy.signal has been deprecated since [scipy 1.8.0](https://docs.scipy.org/doc/scipy-1.8.1/release.1.1.0.html). Changing our imports to the new location will require to change in setup.py the requirements

`'scipy>=1.7.1' to  'scipy>=1.8.0'`

which should probably get some testing.