### PR TITLE
Fix decay estimation of exponential decay model

### DIFF
--- a/src/qudi/util/fit_models/exp_decay.py
+++ b/src/qudi/util/fit_models/exp_decay.py
@@ -94,7 +94,7 @@ class ExponentialDecay(FitModelBase):
         # perform a linear fit on the logarithm of the remaining data
         try:
             poly_coef = np.polyfit(x[:stop_index], np.log(data_smoothed[:stop_index]), deg=1)
-            decay = 1 / np.sqrt(abs(poly_coef[0]))
+            decay = 1 / abs(poly_coef[0])
             amplitude = np.exp(poly_coef[1])
         except:
             warnings.warn('Estimation of decay constant and amplitude failed.')


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

Fix decay estimation of exponential decay model

## Description
<!--- Describe your changes in detail -->

It was noticed that the estimate of the decay parameter is much too high (in the order of 10^-3 instead of the expected 10^-6). In the respective code there is an additional sqrt which seems to be incorrect (linear fit of the logarithm of the data). After removing this sqrt, the estimate look pretty good.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This should improve the exponential-decay-fitting

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested with experimental data and observing the estimation parameters.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [ ] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
