### PR TITLE
List constraint

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,8 @@ None
 - Fixed syntax error in `qudi.util.fit_models.lorentzian.LorentzianLinear` fit model
 
 ### New Features
-None
+- Introduced `DiscreteScalarConstraint` that expands the functionality of `ScalarConstraint` to check whether a value 
+is in a set of discrete values
 
 ### Other
 None

--- a/src/qudi/util/constraints.py
+++ b/src/qudi/util/constraints.py
@@ -364,8 +364,8 @@ class DiscreteScalarConstraint(ScalarConstraint):
                 "Parameters value_set, bounds and increment are None. Please specify either value_set or bounds and increment."
             )
 
-        super().__init__(default, bounds, increment, enforce_int, checker)
         self._precision = precision
+        super().__init__(default, bounds, increment, enforce_int, checker)
 
         if not self.is_valid(self._default):
             raise ValueError(f"invalid default value ({self._default}) encountered")

--- a/src/qudi/util/constraints.py
+++ b/src/qudi/util/constraints.py
@@ -59,34 +59,104 @@ class ScalarConstraint:
 
     @property
     def bounds(self) -> Tuple[Union[int, float], Union[int, float]]:
+        """
+        Returns the interval within values are valid in this constraint.
+
+        Returns
+        -------
+        Tuple([int, float], [int, float])
+        """
         return self._minimum, self._maximum
 
     @property
     def minimum(self) -> Union[int, float]:
+        """
+        Returns minimum allowed value.
+
+        Returns
+        -------
+        int, float
+        """
         return self._minimum
 
     @property
     def maximum(self) -> Union[int, float]:
+        """
+        Returns maximum allowed value.
+
+        Returns
+        -------
+        int, float
+        """
         return self._maximum
 
     @property
     def default(self) -> Union[int, float]:
+        """
+        Returns default value.
+
+        Returns
+        -------
+        int, float
+        """
         return self._default
 
     @property
     def increment(self) -> Union[None, int, float]:
+        """
+        Returns the increment between values that is normally used.
+        This is often used for the increment in e.g. QSpinBox.
+
+        Returns
+        -------
+        int, float
+        """
         return self._increment
 
     @property
     def enforce_int(self) -> bool:
+        """
+        Returns whether only integer values are allowed.
+
+        Returns
+        -------
+        bool
+        """
         return self._enforce_int
 
     def check(self, value: Union[int, float]) -> None:
+        """
+        Method that checks whether the given value is allowed by the constraint by calling various checker functions.
+        If a checker function fails it will raise an Exception, indicating what is wrong with the value.
+
+        Parameters
+        ----------
+            int, float
+                value to check
+
+        Returns
+        -------
+        None
+        """
+
         self.check_value_type(value)
         self.check_value_range(value)
         self.check_custom(value)
 
     def is_valid(self, value: Union[int, float]) -> bool:
+        """
+        Method that checks whether the given value is valid.
+
+        Parameters
+        ----------
+            int, float
+                value to check
+
+        Returns
+        -------
+        bool
+            Is the value valid or not
+        """
         try:
             self.check(value)
         except (ValueError, TypeError):
@@ -94,9 +164,30 @@ class ScalarConstraint:
         return True
 
     def clip(self, value: Union[int, float]) -> Union[int, float]:
+        """
+        Method that clips the given value at the bounds of the constraint.
+
+        Parameters
+        ----------
+            int, float
+                value to clip
+
+        Returns
+        -------
+        int, float
+            value if in bounds, or the minimum or maximum allowed value
+        """
         return min(self._maximum, max(self._minimum, value))
 
     def copy(self) -> object:
+        """
+        Method copies this ScalarConstraint instance.
+
+        Returns
+        -------
+        ScalarConstraint
+            Copy of this instance
+        """
         return ScalarConstraint(
             default=self.default,
             bounds=self.bounds,
@@ -106,14 +197,65 @@ class ScalarConstraint:
         )
 
     def check_custom(self, value: Any) -> None:
+        """
+        Method that checks the given value with the supplied custom checker function.
+
+        Parameters
+        ----------
+            int, float
+                value to check
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            If checker function returns False.
+        """
         if (self._checker is not None) and (not self._checker(value)):
             raise ValueError(f'Custom checker failed to validate value "{value}"')
 
     def check_value_range(self, value: Union[int, float]) -> None:
+        """
+        Method that checks the given value if it is in bounds.
+
+        Parameters
+        ----------
+            int, float
+                value to check
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            If value out of bounds.
+        """
         if not (self._minimum <= value <= self._maximum):
             raise ValueError(f'Value "{value}" is out of bounds {self.bounds}')
 
     def check_value_type(self, value: Any) -> None:
+        """
+        Method that checks the given value if it is in bounds.
+
+        Parameters
+        ----------
+            int, float
+                value to check
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        TypeError
+            If value is not int or float or if _enforce_int is set if it is not int.
+        """
         if self._enforce_int:
             if not is_integer(value):
                 raise TypeError(f"values must be int type (received {value})")
@@ -122,6 +264,14 @@ class ScalarConstraint:
                 raise TypeError(f"values must be int or float type (received {value})")
 
     def __repr__(self) -> str:
+        """
+        Method that gives a readable representation of this constraint.
+
+        Returns
+        -------
+        str
+            Readable representation of the constraint.
+        """
         cls = self.__class__.__name__
         module = self.__class__.__module__
         return (
@@ -134,9 +284,25 @@ class ScalarConstraint:
         )
 
     def __copy__(self):
+        """
+        Returns the copy of this instance.
+
+        Returns
+        -------
+        ScalarConstraint
+            Copy of this instance
+        """
         return self.copy()
 
     def __deepcopy__(self, memodict={}):
+        """
+        Returns the deepcopy of this instance.
+
+        Returns
+        -------
+        ScalarConstraint
+            Deepcopy of this instance
+        """
         new_obj = self.copy()
         memodict[id(self)] = new_obj
         return new_obj
@@ -213,24 +379,59 @@ class DiscreteScalarConstraint(ScalarConstraint):
     @property
     def value_set(self) -> Set[Union[int, float]]:
         """
-        Set of values that the constraint allows.
+        Returns the set of values that the constraint allows.
+
+        Returns
+        -------
+        set([int, float])
         """
         return self._value_set
 
     @property
     def precision(self) -> float:
         """
-        Precision with which floating point discrete values are checked for equality.
+        Returns the precision with which floating point discrete values are checked for equality.
+
+        Returns
+        -------
+        float
         """
         return self._precision
 
     def check(self, value: Union[int, float]) -> None:
-        self.check_value_type(value)
-        self.check_value_range(value)
+        """
+        Method that utilizes the check function of ScalarConstraint and expands it by checking whether the given value is in the discrete value set.
+
+        Parameters
+        ----------
+            int, float
+                value to check
+
+        Returns
+        -------
+        None
+        """
+        super().check(value)
         self.check_value_set(value)
-        self.check_custom(value)
 
     def check_value_set(self, value: Union[int, float]):
+        """
+        Method that checks whether the given value is in the discrete value set.
+
+        Parameters
+        ----------
+            int, float
+                value to check
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            If value is not in discrete value set.
+        """
         if value in self.value_set:
             return
 
@@ -242,6 +443,14 @@ class DiscreteScalarConstraint(ScalarConstraint):
         raise ValueError(f"Value {value} is not in allowed discrete value set.")
 
     def copy(self) -> object:
+        """
+        Method copies this DiscreteScalarConstraint instance.
+
+        Returns
+        -------
+        DiscreteScalarConstraint
+            Copy of this instance
+        """
         return DiscreteScalarConstraint(
             default=self.default,
             value_set=self.value_set,
@@ -253,6 +462,14 @@ class DiscreteScalarConstraint(ScalarConstraint):
         )
 
     def __repr__(self) -> str:
+        """
+        Method that gives a readable representation of this constraint.
+
+        Returns
+        -------
+        str
+            Readable representation of the constraint.
+        """
         cls = self.__class__.__name__
         module = self.__class__.__module__
         return (

--- a/src/qudi/util/constraints.py
+++ b/src/qudi/util/constraints.py
@@ -2,8 +2,8 @@
 """
 This file contains Qudi methods for handling real-world values with units.
 
-Copyright (c) 2021, the qudi developers. See the AUTHORS.md file at the top-level directory of this
-distribution and on <https://github.com/Ulm-IQO/qudi-core/>
+Copyright (c) 2021-2024, the qudi developers. See the AUTHORS.md file at the top-level directory of
+this distribution and on <https://github.com/Ulm-IQO/qudi-core/>
 
 This file is part of qudi.
 
@@ -21,13 +21,43 @@ If not, see <https://www.gnu.org/licenses/>.
 
 __all__ = ['ScalarConstraint', 'DiscreteScalarConstraint']
 
-from typing import Union, Optional, Tuple, Callable, Any, Set
+import warnings
+from bisect import bisect_left
+from typing import Union, Optional, Tuple, Callable, Any, Iterable
+
 from qudi.util.helpers import is_float, is_integer
-import numpy as np
+
 
 
 class ScalarConstraint:
     """
+    Immutable helper object representing the numeric constraints for a scalar number within a
+    certain continuous value range.
+    Has built-in helper methods to check values against the constraints or clip them to the nearest
+    allowed value.
+
+    Attributes
+    ----------
+    bounds
+    minimum
+    maximum
+    default
+    increment
+    enforce_int
+
+    Parameters
+    ----------
+    default : int or float
+        Default value to use for this scalar.
+    bounds : tuple
+        Min and max boundary (inclusive) for the allowed value range.
+    increment : int or float, optional
+        Default natural step size for value changes. Only used as additional information and not
+        for value checking.
+    enforce_int : bool, optional
+        Flag indicating if this scalar should be enforced to be of integer type
+    checker : callable, optional
+        Custom checker function to accept a scalar value and raise ValueError or TypeError on fail.
     """
     def __init__(self,
                  default: Union[int, float],
@@ -36,8 +66,6 @@ class ScalarConstraint:
                  enforce_int: Optional[bool] = False,
                  checker: Optional[Callable[[Union[int, float]], bool]] = None
                  ) -> None:
-        """
-        """
         self._enforce_int = bool(enforce_int)
         self.check_value_type(default)
         for value in bounds:
@@ -58,63 +86,65 @@ class ScalarConstraint:
     @property
     def bounds(self) -> Tuple[Union[int, float], Union[int, float]]:
         """
-        Returns the interval within values are valid in this constraint.
+        Interval (inclusive) for valid value range.
 
         Returns
         -------
-        Tuple([int, float], [int, float])
+        int or float
+            Minimum allowed value
+        int or float
+            Maximum allowed value
         """
         return self._minimum, self._maximum
 
     @property
     def minimum(self) -> Union[int, float]:
         """
-        Returns minimum allowed value.
+        Minimum allowed value.
 
         Returns
         -------
-        int, float
+        int or float
         """
         return self._minimum
 
     @property
     def maximum(self) -> Union[int, float]:
         """
-        Returns maximum allowed value.
+        Maximum allowed value.
 
         Returns
         -------
-        int, float
+        int or float
         """
         return self._maximum
 
     @property
     def default(self) -> Union[int, float]:
         """
-        Returns default value.
+        Default fallback value.
 
         Returns
         -------
-        int, float
+        int or float
         """
         return self._default
 
     @property
     def increment(self) -> Union[None, int, float]:
         """
-        Returns the increment between values that is normally used.
-        This is often used for the increment in e.g. QSpinBox.
+        Natural increment to increase/decrease values. This is often used in a GUI, e.g. QSpinBox.
 
         Returns
         -------
-        int, float
+        int or float
         """
         return self._increment
 
     @property
     def enforce_int(self) -> bool:
         """
-        Returns whether only integer values are allowed.
+        Flag indicating if this scalar should be enforced to be of integer type
 
         Returns
         -------
@@ -124,36 +154,39 @@ class ScalarConstraint:
 
     def check(self, value: Union[int, float]) -> None:
         """
-        Method that checks whether the given value is allowed by the constraint by calling various checker functions.
-        If a checker function fails it will raise an Exception, indicating what is wrong with the value.
+        Checks whether the given value is allowed by the constraint by calling various checker
+        functions. If a checker function fails it will raise an Exception, indicating what is wrong
+        with the checked value.
 
         Parameters
         ----------
-            int, float
-                value to check
+        value : int or float
+            value to check
 
-        Returns
-        -------
-        None
+        Raises
+        ------
+        ValueError
+            If the value is incompatible with the constraints
+        TypeError
+            If the value type is incompatible with the constraints, e.g. in case of
+            enforce_int == True
         """
-
         self.check_value_type(value)
         self.check_value_range(value)
         self.check_custom(value)
 
     def is_valid(self, value: Union[int, float]) -> bool:
         """
-        Method that checks whether the given value is valid.
+        Checks whether the given value is valid.
 
         Parameters
         ----------
-            int, float
-                value to check
+        value : int or float
+            value to check
 
         Returns
         -------
         bool
-            Is the value valid or not
         """
         try:
             self.check(value)
@@ -163,23 +196,22 @@ class ScalarConstraint:
 
     def clip(self, value: Union[int, float]) -> Union[int, float]:
         """
-        Method that clips the given value at the bounds of the constraint.
+        Clips the given value to the nearest valid value.
 
         Parameters
         ----------
-            int, float
-                value to clip
+        value : int or float
+            value to clip
 
         Returns
         -------
-        int, float
-            value if in bounds, or the minimum or maximum allowed value
+        int or float
         """
         return min(self._maximum, max(self._minimum, value))
 
     def copy(self) -> object:
         """
-        Method copies this ScalarConstraint instance.
+        Copies this ScalarConstraint instance.
 
         Returns
         -------
@@ -192,39 +224,33 @@ class ScalarConstraint:
                                 enforce_int=self.enforce_int,
                                 checker=self._checker)
 
-    def check_custom(self, value: Any) -> None:
+    def check_custom(self, value: Union[int, float]) -> None:
         """
-        Method that checks the given value with the supplied custom checker function.
+        Checks the given value with the supplied custom checker function.
 
         Parameters
         ----------
-            int, float
-                value to check
-
-        Returns
-        -------
-        None
+        value : int or float
+            value to check
 
         Raises
         ------
         ValueError
-            If checker function returns False.
+            If custom checker fails to validate.
+        TypeError
+            If custom checker fails to validate.
         """
         if (self._checker is not None) and (not self._checker(value)):
-            raise ValueError(f'Custom checker failed to validate value "{value}"')
+            raise ValueError(f'Custom checker failed to validate {value}')
 
     def check_value_range(self, value: Union[int, float]) -> None:
         """
-        Method that checks the given value if it is in bounds.
+        Checks the given value if it is in bounds.
 
         Parameters
         ----------
-            int, float
-                value to check
-
-        Returns
-        -------
-        None
+        value : int or float
+            value to check
 
         Raises
         ------
@@ -236,16 +262,12 @@ class ScalarConstraint:
 
     def check_value_type(self, value: Any) -> None:
         """
-        Method that checks the given value if it is in bounds.
+        Checks the given value if it is in bounds.
 
         Parameters
         ----------
-            int, float
-                value to check
-
-        Returns
-        -------
-        None
+        value : int or float
+            value to check
 
         Raises
         ------
@@ -260,14 +282,6 @@ class ScalarConstraint:
                 raise TypeError(f'values must be int or float type (received {value})')
 
     def __repr__(self) -> str:
-        """
-        Method that gives a readable representation of this constraint.
-
-        Returns
-        -------
-        str
-            Readable representation of the constraint.
-        """
         cls = self.__class__.__name__
         module = self.__class__.__module__
         return f'{module}.{cls}(' \
@@ -278,25 +292,9 @@ class ScalarConstraint:
                f'checker={self._checker})'
 
     def __copy__(self):
-        """
-        Returns the copy of this instance.
-
-        Returns
-        -------
-        ScalarConstraint
-            Copy of this instance
-        """
         return self.copy()
 
     def __deepcopy__(self, memodict={}):
-        """
-        Returns the deepcopy of this instance.
-
-        Returns
-        -------
-        ScalarConstraint
-            Deepcopy of this instance
-        """
         new_obj = self.copy()
         memodict[id(self)] = new_obj
         return new_obj
@@ -304,76 +302,153 @@ class ScalarConstraint:
     # Backwards compatibility properties:
     @default.setter
     def default(self, value: Union[int, float]):
+        """
+        .. deprecated:: 1.3.0
+            constraints should be immutable. Pass all values to :py:func:`__init__` instead.
+        """
+        warnings.warn('ScalarConstraint should be immutable. Pass all values to __init__ instead.',
+                      DeprecationWarning,
+                      stacklevel=2)
         if not self.is_valid(value):
             raise ValueError(f'invalid default value ({value}) encountered')
         self._default = value
 
     @property
     def min(self) -> Union[int, float]:
+        """
+        .. deprecated:: 1.3.0
+            ScalarConstraint.min will be removed in the near future. Use ScalarConstraint.minimum
+            instead.
+        """
+        warnings.warn('ScalarConstraint.min will be removed in the near future. '
+                      'Use ScalarConstraint.minimum instead.',
+                      DeprecationWarning,
+                      stacklevel=2)
         return self._minimum
 
     @min.setter
     def min(self, value: Union[int, float]):
+        """
+        .. deprecated:: 1.3.0
+            constraints should be immutable. Pass all values to :py:func:`__init__` instead.
+        """
+        warnings.warn('ScalarConstraint should be immutable. Pass all values to __init__ instead.',
+                      DeprecationWarning,
+                      stacklevel=2)
         self._minimum = value
 
     @property
     def max(self) -> Union[int, float]:
+        """
+        .. deprecated:: 1.3.0
+            ScalarConstraint.max will be removed in the near future. Use ScalarConstraint.maximum
+            instead.
+        """
+        warnings.warn('ScalarConstraint.max will be removed in the near future. '
+                      'Use ScalarConstraint.maximum instead.',
+                      DeprecationWarning,
+                      stacklevel=2)
         return self._maximum
 
     @max.setter
     def max(self, value: Union[int, float]):
+        """
+        .. deprecated:: 1.3.0
+            constraints should be immutable. Pass all values to :py:func:`__init__` instead.
+        """
+        warnings.warn('ScalarConstraint should be immutable. Pass all values to __init__ instead.',
+                      DeprecationWarning,
+                      stacklevel=2)
         self._maximum = value
 
     @property
     def step(self) -> Union[None, int, float]:
+        """
+        .. deprecated:: 1.3.0
+            ScalarConstraint.step will be removed in the near future. Use ScalarConstraint.increment
+            instead.
+        """
+        warnings.warn('ScalarConstraint.step will be removed in the near future. '
+                      'Use ScalarConstraint.increment instead.',
+                      DeprecationWarning,
+                      stacklevel=2)
         return self._increment
 
     @step.setter
     def step(self, value: Union[None, int, float]):
+        """
+        .. deprecated:: 1.3.0
+            constraints should be immutable. Pass all values to :py:func:`__init__` instead.
+        """
+        warnings.warn('ScalarConstraint should be immutable. Pass all values to __init__ instead.',
+                      DeprecationWarning,
+                      stacklevel=2)
         self._increment = value
 
 
 class DiscreteScalarConstraint(ScalarConstraint):
-    """ """
+    """
+    Specialization of ScalarConstraint for arbitrary discrete sets of allowed scalar values.
+
+    Attributes
+    ----------
+    allowed_values
+    precision
+    default
+    enforce_int
+
+    Parameters
+    ----------
+    default : int or float
+        Default value to use for this scalar.
+    allowed_values : iterable
+        Complete collection of allowed scalar values.
+    precision : float, optional
+        Maximum deviation a checked value is allowed to have from the nearest valid value (default
+        is exact matching)
+    enforce_int : bool, optional
+        Flag indicating if this scalar should be enforced to be of integer type
+    checker : callable, optional
+        Custom checker function to accept a scalar value and raise ValueError or TypeError on fail.
+    """
 
     def __init__(
         self,
         default: Union[int, float],
-        value_set: Set[Union[int, float]],
+        allowed_values: Iterable[Union[int, float]],
+        precision: Optional[float] = None,
         enforce_int: Optional[bool] = False,
         checker: Optional[Callable[[Union[int, float]], bool]] = None,
-        precision: Optional[float] = None,
     ) -> None:
-        """ """
-        self._value_set = value_set
-        bounds = (min(self._value_set), max(self._value_set))
-        self._precision = precision
-
+        # sort tuple for efficient checking
+        self._allowed_values = tuple(sorted(set(allowed_values)))
+        self._precision = None if (precision is None or precision == 0) else abs(precision)
+        if len(self._allowed_values) == 0:
+            raise ValueError('Must provide at least one allowed value')
+        if not all(isinstance(val, int) for val in self._allowed_values):
+            raise TypeError('Allowed values must be int type for `enforce_int == True`')
         super().__init__(
             default=default,
-            bounds=bounds,
+            bounds=(min(self._allowed_values), max(self._allowed_values)),
             enforce_int=enforce_int,
             checker=checker,
         )
 
-        if not self.is_valid(self._default):
-            raise ValueError(f"invalid default value ({self._default}) encountered")
-
     @property
-    def value_set(self) -> Set[Union[int, float]]:
+    def allowed_values(self) -> Tuple[Union[int, float], ...]:
         """
-        Returns the set of values that the constraint allows.
+        Discrete collection of values that the constraint allows.
 
         Returns
         -------
-        set([int, float])
+        tuple
         """
-        return self._value_set
+        return self._allowed_values
 
     @property
     def precision(self) -> float:
         """
-        Returns the precision with which floating point discrete values are checked for equality.
+        Precision with which floating point discrete values are checked for equality.
 
         Returns
         -------
@@ -382,50 +457,35 @@ class DiscreteScalarConstraint(ScalarConstraint):
         return self._precision
 
     def check(self, value: Union[int, float]) -> None:
-        """
-        Method that utilizes the check function of ScalarConstraint and expands it by checking whether the given value is in the discrete value set.
-
-        Parameters
-        ----------
-            int, float
-                value to check
-
-        Returns
-        -------
-        None
-        """
         super().check(value)
-        self.check_value_set(value)
+        self.check_allowed_values(value)
 
-    def check_value_set(self, value: Union[int, float]):
+    def check_allowed_values(self, value: Union[int, float]) -> None:
         """
-        Method that checks whether the given value is in the discrete value set.
+        Method that checks whether the given value is in the set of allowed discrete values.
 
         Parameters
         ----------
-            int, float
-                value to check
-
-        Returns
-        -------
-        None
+        value : int or float
+            value to check
 
         Raises
         ------
         ValueError
             If value is not in discrete value set.
         """
-        if value in self.value_set:
-            return
+        closest_allowed = self._find_closest_value(value)
+        # Use == operator here since checking for identity can lead to problems with proxy objects
+        if closest_allowed != value:
+            if self.precision is not None and abs(closest_allowed - value) < self.precision:
+                pass
+            else:
+                raise ValueError(f"Value {value} is not in allowed discrete value set.")
 
-        if self.precision is not None:
-            for val in self.value_set:
-                if abs(val - value) < abs(self.precision):
-                    return
+    def clip(self, value: Union[int, float]) -> Union[int, float]:
+        return self._find_closest_value(value)
 
-        raise ValueError(f"Value {value} is not in allowed discrete value set.")
-
-    def copy(self) -> object:
+    def copy(self) -> 'DiscreteScalarConstraint':
         """
         Method copies this DiscreteScalarConstraint instance.
 
@@ -436,9 +496,7 @@ class DiscreteScalarConstraint(ScalarConstraint):
         """
         return DiscreteScalarConstraint(
             default=self.default,
-            value_set=self.value_set,
-            bounds=self.bounds,
-            increment=self.increment,
+            allowed_values=self.allowed_values,
             enforce_int=self.enforce_int,
             checker=self._checker,
             precision=self.precision,
@@ -458,10 +516,24 @@ class DiscreteScalarConstraint(ScalarConstraint):
         return (
             f"{module}.{cls}("
             f"default={self.default}, "
-            f"value_set={self.value_set}, "
-            f"bounds={self.bounds}, "
-            f"increment={self.increment}, "
+            f"allowed_values={self.allowed_values}, "
             f"enforce_int={self.enforce_int}, "
             f"checker={self._checker},"
             f"precision={self.precision})"
         )
+
+    def _find_closest_value(self, value: Union[int, float]) -> Union[int, float]:
+        """Find allowed value closest to given value"""
+        pos = bisect_left(self._allowed_values, value)
+        if pos == 0:
+            closest = self._allowed_values[pos]
+        elif pos == len(self._allowed_values):
+            closest = self._allowed_values[-1]
+        else:
+            before = self._allowed_values[pos - 1]
+            after = self._allowed_values[pos]
+            if value - before >= after - value:
+                closest = after
+            else:
+                closest = before
+        return closest

--- a/src/qudi/util/constraints.py
+++ b/src/qudi/util/constraints.py
@@ -258,10 +258,12 @@ class ScalarConstraint:
         """
         if self._enforce_int:
             if not is_integer(value):
-                raise TypeError(f"values must be int type (received {value})")
+                raise TypeError(f"values must be int type (received {type(value)})")
         else:
             if not (is_integer(value) or is_float(value)):
-                raise TypeError(f"values must be int or float type (received {value})")
+                raise TypeError(
+                    f"values must be int or float type (received {type(value)})"
+                )
 
     def __repr__(self) -> str:
         """

--- a/src/qudi/util/constraints.py
+++ b/src/qudi/util/constraints.py
@@ -421,12 +421,12 @@ class DiscreteScalarConstraint(ScalarConstraint):
         checker: Optional[Callable[[Union[int, float]], bool]] = None,
     ) -> None:
         # sort tuple for efficient checking
+        if enforce_int:
+            allowed_values = (int(val) for val in allowed_values)
         self._allowed_values = tuple(sorted(set(allowed_values)))
         self._precision = None if (precision is None or precision == 0) else abs(precision)
         if len(self._allowed_values) == 0:
             raise ValueError('Must provide at least one allowed value')
-        if not all(isinstance(val, int) for val in self._allowed_values):
-            raise TypeError('Allowed values must be int type for `enforce_int == True`')
         super().__init__(
             default=default,
             bounds=(min(self._allowed_values), max(self._allowed_values)),

--- a/src/qudi/util/constraints.py
+++ b/src/qudi/util/constraints.py
@@ -349,7 +349,12 @@ class DiscreteScalarConstraint(ScalarConstraint):
         bounds = (min(self._value_set), max(self._value_set))
         self._precision = precision
 
-        super().__init__(default=default, bounds=bounds, enforce_int=enforce_int, checker=checker)
+        super().__init__(
+            default=default,
+            bounds=bounds,
+            enforce_int=enforce_int,
+            checker=checker,
+        )
 
         if not self.is_valid(self._default):
             raise ValueError(f"invalid default value ({self._default}) encountered")

--- a/src/qudi/util/constraints.py
+++ b/src/qudi/util/constraints.py
@@ -339,33 +339,17 @@ class DiscreteScalarConstraint(ScalarConstraint):
     def __init__(
         self,
         default: Union[int, float],
-        value_set: Optional[Set[Union[int, float]]] = None,
-        bounds: Optional[Tuple[Union[int, float], Union[int, float]]] = None,
-        increment: Optional[Union[int, float]] = None,
+        value_set: Set[Union[int, float]],
         enforce_int: Optional[bool] = False,
         checker: Optional[Callable[[Union[int, float]], bool]] = None,
         precision: Optional[float] = None,
     ) -> None:
         """ """
-        if value_set is not None:
-            self._value_set = value_set
-            if bounds is not None:
-                raise ValueError(
-                    "Parameters value_set and bounds are both set simultaneously. Don't specify bounds as they are calculated from min and max value of value_set."
-                )
-            bounds = (min(self._value_set), max(self._value_set))
-
-        elif bounds is not None and increment is not None:
-            bounds = sorted(bounds)
-            self._value_set = set(np.arange(bounds[0], bounds[1], increment))
-
-        else:
-            raise ValueError(
-                "Parameters value_set, bounds and increment are None. Please specify either value_set or bounds and increment."
-            )
-
+        self._value_set = value_set
+        bounds = (min(self._value_set), max(self._value_set))
         self._precision = precision
-        super().__init__(default, bounds, increment, enforce_int, checker)
+
+        super().__init__(default=default, bounds=bounds, enforce_int=enforce_int, checker=checker)
 
         if not self.is_valid(self._default):
             raise ValueError(f"invalid default value ({self._default}) encountered")

--- a/src/qudi/util/constraints.py
+++ b/src/qudi/util/constraints.py
@@ -19,7 +19,7 @@ You should have received a copy of the GNU Lesser General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 """
 
-__all__ = ["ScalarConstraint"]
+__all__ = ['ScalarConstraint', 'DiscreteScalarConstraint']
 
 from typing import Union, Optional, Tuple, Callable, Any, Set
 from qudi.util.helpers import is_float, is_integer
@@ -27,17 +27,17 @@ import numpy as np
 
 
 class ScalarConstraint:
-    """ """
-
-    def __init__(
-        self,
-        default: Union[int, float],
-        bounds: Tuple[Union[int, float], Union[int, float]],
-        increment: Optional[Union[int, float]] = None,
-        enforce_int: Optional[bool] = False,
-        checker: Optional[Callable[[Union[int, float]], bool]] = None,
-    ) -> None:
-        """ """
+    """
+    """
+    def __init__(self,
+                 default: Union[int, float],
+                 bounds: Tuple[Union[int, float], Union[int, float]],
+                 increment: Optional[Union[int, float]] = None,
+                 enforce_int: Optional[bool] = False,
+                 checker: Optional[Callable[[Union[int, float]], bool]] = None
+                 ) -> None:
+        """
+        """
         self._enforce_int = bool(enforce_int)
         self.check_value_type(default)
         for value in bounds:
@@ -45,17 +45,15 @@ class ScalarConstraint:
         if increment is not None:
             self.check_value_type(increment)
         if checker is not None and not callable(checker):
-            raise TypeError(
-                "checker must be either None or a callable accepting a single scalar "
-                "and returning a valid-flag bool or raising ValueError"
-            )
+            raise TypeError('checker must be either None or a callable accepting a single scalar '
+                            'and returning a valid-flag bool or raising ValueError')
         self._default = default
         self._minimum, self._maximum = sorted(bounds)
         self._increment = increment
         self._checker = checker
 
         if not self.is_valid(self._default):
-            raise ValueError(f"invalid default value ({self._default}) encountered")
+            raise ValueError(f'invalid default value ({self._default}) encountered')
 
     @property
     def bounds(self) -> Tuple[Union[int, float], Union[int, float]]:
@@ -188,13 +186,11 @@ class ScalarConstraint:
         ScalarConstraint
             Copy of this instance
         """
-        return ScalarConstraint(
-            default=self.default,
-            bounds=self.bounds,
-            increment=self.increment,
-            enforce_int=self.enforce_int,
-            checker=self._checker,
-        )
+        return ScalarConstraint(default=self.default,
+                                bounds=self.bounds,
+                                increment=self.increment,
+                                enforce_int=self.enforce_int,
+                                checker=self._checker)
 
     def check_custom(self, value: Any) -> None:
         """
@@ -258,12 +254,10 @@ class ScalarConstraint:
         """
         if self._enforce_int:
             if not is_integer(value):
-                raise TypeError(f"values must be int type (received {type(value)})")
+                raise TypeError(f'values must be int type (received {value})')
         else:
             if not (is_integer(value) or is_float(value)):
-                raise TypeError(
-                    f"values must be int or float type (received {type(value)})"
-                )
+                raise TypeError(f'values must be int or float type (received {value})')
 
     def __repr__(self) -> str:
         """
@@ -276,14 +270,12 @@ class ScalarConstraint:
         """
         cls = self.__class__.__name__
         module = self.__class__.__module__
-        return (
-            f"{module}.{cls}("
-            f"default={self.default}, "
-            f"bounds={self.bounds}, "
-            f"increment={self.increment}, "
-            f"enforce_int={self.enforce_int}, "
-            f"checker={self._checker})"
-        )
+        return f'{module}.{cls}(' \
+               f'default={self.default}, ' \
+               f'bounds={self.bounds}, ' \
+               f'increment={self.increment}, ' \
+               f'enforce_int={self.enforce_int}, ' \
+               f'checker={self._checker})'
 
     def __copy__(self):
         """
@@ -313,7 +305,7 @@ class ScalarConstraint:
     @default.setter
     def default(self, value: Union[int, float]):
         if not self.is_valid(value):
-            raise ValueError(f"invalid default value ({value}) encountered")
+            raise ValueError(f'invalid default value ({value}) encountered')
         self._default = value
 
     @property


### PR DESCRIPTION
## Description
Added `DiscreteScalarConstraint` that expands the capability of checking whether a value is in bounds to also check whether it is in a discrete value set. Also added some descriptive docstrings from the discussion in the qudi meeting.

## Motivation and Context
Sometimes a `ScalarConstraint` that only checks whether a value is in bounds is not sufficient. Some devices can only set values from a certain set of discrete values. `DiscreteScalarConstraint` offers the possibility to check whether a value is not only in bounds but also matches the discrete value set of the constraint. It accepts integers and floating point values. For the latter a precision can be specified up until which the equality of the value and the underlying discrete value set is checked against.

## How Has This Been Tested?
Created an instance of the class with discrete value set (int and float) and checked for different values (int and float) if the checkers behave as expected.

## Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
