### PR TITLE
Qudi deadlocking when launching GUI modules via ipython terminal

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@
 None
 
 ### Bugfixes
-None
+- Fixed a bug where qudi would deadlock when starting a GUI module via the ipython terminal
 
 ### New Features
 None
@@ -41,10 +41,10 @@ Released on 16.11.2023
 None
 
 ### Bugfixes
-- Fixes a bug where all fit configurations for a fit model/container fail to load upon activation 
-of a module because the fit model saved in AppData is no longer available. Throws a warning now 
+- Fixes a bug where all fit configurations for a fit model/container fail to load upon activation
+of a module because the fit model saved in AppData is no longer available. Throws a warning now
 instead and ignores the respective fit configuration.
-- Fixed a bug that caused `qudi.util.models.DictTableModel` to raise `IndexError` when used in a 
+- Fixed a bug that caused `qudi.util.models.DictTableModel` to raise `IndexError` when used in a
 `ListView` and/or when data at index zero is requested.
 
 ### New Features
@@ -65,12 +65,12 @@ None
 None
 
 ### New Features
-- Added utility descriptor objects to new module `qudi.util.descriptors`. Can be used to 
-facilitate smart instance attribute handling. 
+- Added utility descriptor objects to new module `qudi.util.descriptors`. Can be used to
+facilitate smart instance attribute handling.
 
 ### Other
 - Support for Python 3.10
-- Better backwards compatibility of `qudi.util.constraints.ScalarConstraint` with the deprecated 
+- Better backwards compatibility of `qudi.util.constraints.ScalarConstraint` with the deprecated
 `qudi.core.interface.ScalarConstraint` object
 
 
@@ -81,20 +81,20 @@ Released on 20.12.2022
 None
 
 ### Bugfixes
-- NULL bytes in log messages are handled now and no longer lead to crashes of qudi. They are 
+- NULL bytes in log messages are handled now and no longer lead to crashes of qudi. They are
 replaced by the corresponding hex literal "\x00".
-- Rubberband selection of utility plot widgets now works for `pyqtgraph != 0.12.4`. This specific 
+- Rubberband selection of utility plot widgets now works for `pyqtgraph != 0.12.4`. This specific
 version is broken in that regard and a comprehensive error is thrown if it is detected.
 - Adjusted 2D gaussian fit arguments to be compatible with the datafitting toolchain.
 
 ### New Features
-- Multiple qudi sessions can now be run in parallel locally. However, the user must ensure 
-non-conflicting socket server settings for namespace server and remote module server in the 
+- Multiple qudi sessions can now be run in parallel locally. However, the user must ensure
+non-conflicting socket server settings for namespace server and remote module server in the
 configs to load.
 
 ### Other
 - Bumped minimum package requirement `pyqtgraph >= 0.13.0`.
-- Introduced properties to make `qudi.util.constraints.ScalarConstraint` mostly backwards 
+- Introduced properties to make `qudi.util.constraints.ScalarConstraint` mostly backwards
 compatible with the deprecated `qudi.core.interface.ScalarConstraint`. Only exception is `unit`
 which should not be supported anymore.
 
@@ -109,8 +109,8 @@ None
 None
 
 ### New Features
-- New general-purpose interactive data display widget 
-`qudi.util.widgets.plotting.interactive_curve.InteractiveCurvesWidget` providing multiple optional 
+- New general-purpose interactive data display widget
+`qudi.util.widgets.plotting.interactive_curve.InteractiveCurvesWidget` providing multiple optional
 features:
   - Legend creation and generic dataset naming
   - Linking of fit curve to dataset and synchronous handling of both
@@ -130,10 +130,10 @@ None
 Released on 25.07.2022
 
 ### Breaking Changes
-- Changed event handling of qudi module state machine. `on_deactivate` will be run BEFORE the state 
+- Changed event handling of qudi module state machine. `on_deactivate` will be run BEFORE the state
 machine actually changes into state `deactivated`.
-- `ConfigOption` meta-attributes of qudi modules are no longer set in config under the module name 
-section directly, but must be specified in an `options` subsection instead.  
+- `ConfigOption` meta-attributes of qudi modules are no longer set in config under the module name
+section directly, but must be specified in an `options` subsection instead.
 So something like
   ```python
   my_module_name:
@@ -155,16 +155,16 @@ So something like
 - Reduced RPyC related errors in qudi IPython kernel
 
 ### New Features
-- Support for `enum.Enum` types in `qudi.util.yaml`, enabling use of enums in qudi config and 
+- Support for `enum.Enum` types in `qudi.util.yaml`, enabling use of enums in qudi config and
 status variables.
-- `qudi.util.constraints.ScalarConstraint` data class to easily define bounds for, check and clip 
+- `qudi.util.constraints.ScalarConstraint` data class to easily define bounds for, check and clip
 scalar values.
-- Added qudi logger object to qudi IPython kernels to give users the possibility to directly log 
+- Added qudi logger object to qudi IPython kernels to give users the possibility to directly log
 messages into qudi from e.g. a jupyter notebook.
 
 ### Other
-- Structure and type checking as well as default value handling in the qudi configuration file is 
-now done via JSON Schema (Draft-07). The applied schema is defined in `qudi.core.config.schema`.  
-Every time you load/dump a configuration from/to file or add/remove a module config or set a global 
-config option using `qudi.core.config.Configuration`, the config is validated against this JSON 
+- Structure and type checking as well as default value handling in the qudi configuration file is
+now done via JSON Schema (Draft-07). The applied schema is defined in `qudi.core.config.schema`.
+Every time you load/dump a configuration from/to file or add/remove a module config or set a global
+config option using `qudi.core.config.Configuration`, the config is validated against this JSON
 schema.

--- a/src/qudi/core/modulemanager.py
+++ b/src/qudi/core/modulemanager.py
@@ -670,7 +670,6 @@ class ManagedModule(QtCore.QObject):
     def reload(self):
         # Switch to the main thread if this method was called from another thread
         if QtCore.QThread.currentThread() is not self.thread():
-            logger.debug('changing thread')
             QtCore.QMetaObject.invokeMethod(self, 'reload', QtCore.Qt.BlockingQueuedConnection)
             return
 

--- a/src/qudi/core/modulemanager.py
+++ b/src/qudi/core/modulemanager.py
@@ -194,6 +194,13 @@ class ModuleManager(QtCore.QObject):
                                                module_name in mod_ref().connection_cfg.values())
 
     def activate_module(self, module_name):
+        if QtCore.QThread.currentThread() is not self.thread():
+            self.current_module_name = module_name
+            QtCore.QMetaObject.invokeMethod(self,
+            "_activate_module_slot",
+            QtCore.Qt.BlockingQueuedConnection)
+            return
+
         with self._lock:
             if module_name not in self._modules:
                 raise KeyError(f'No module named "{module_name}" found in managed qudi modules. '
@@ -201,6 +208,13 @@ class ModuleManager(QtCore.QObject):
             self._modules[module_name].activate()
 
     def deactivate_module(self, module_name):
+        if QtCore.QThread.currentThread() is not self.thread():
+            self.current_module_name = module_name
+            QtCore.QMetaObject.invokeMethod(self,
+            "_deactivate_module_slot",
+            QtCore.Qt.BlockingQueuedConnection)
+            return
+
         with self._lock:
             if module_name not in self._modules:
                 raise KeyError(f'No module named "{module_name}" found in managed qudi modules. '
@@ -245,6 +259,20 @@ class ModuleManager(QtCore.QObject):
         logger.error('Qudi main reference no longer valid. This should never happen. Tearing down '
                      'ModuleManager.')
         self.clear()
+
+    @QtCore.Slot()
+    def _activate_module_slot(self):
+        """
+        Helper slot that should only be called by activate_module when this method is switching to the main thread.
+        """
+        self.activate_module(self.current_module_name)
+
+    @QtCore.Slot()
+    def _deactivate_module_slot(self):
+        """
+        Helper slot that should only be called by deactivate_module when this method is switching to the main thread.
+        """
+        self.deactivate_module(self.current_module_name)
 
 
 class ManagedModule(QtCore.QObject):
@@ -642,6 +670,7 @@ class ManagedModule(QtCore.QObject):
     def reload(self):
         # Switch to the main thread if this method was called from another thread
         if QtCore.QThread.currentThread() is not self.thread():
+            logger.debug('changing thread')
             QtCore.QMetaObject.invokeMethod(self, 'reload', QtCore.Qt.BlockingQueuedConnection)
             return
 


### PR DESCRIPTION
## Description
When launching a GUI module via the ipython terminal Qudi will deadlock and needs to be shutdown using the task manager. This originates from the Mutex locks being placed during the activation of the module in the modulemanager. 

When calling `qudi.module_manager.activate_module('<module_name>')` qudi will freeze. Backtracking the freezing leads to method `Gui._tray_module_action_changed` in `qudi-core\src\qudi\core\gui\gui.py`. More precisely it fails in line `386` when the instance of the module manager is retrieved. This happens, because in `ModuleManager.instance` in `qudi-core\src\qudi\core\modulemanager.py` a thread lock is applied. If the GUI module is activated via the main GUI of qudi this imposes no problem as everything is done in the main thread and thus all locks are applied from the main thread. When using the ipython terminal `ModuleManager.activate_module` is called from its thread. This method only returns and thus only opens up its thread lock when the called `ManagedModule.activate` method terminates. In this method however, a thread check is done and if the method was not called from main thread it switches to it. From here on everything will be called in the main thread.
When reaching the above mentioned line `386` the thread lock when retrieving the instance is applied from the main thread.
Because the initial function call was done in a different thread (which has yet to finish) the instance of modulemanager can't be accessed and qudi deadlocks.

The problem with the thread lock deadlock was first discovered by @astropiuu. 

It is fixed by switching to the main thread in `ModuleManager.activate_module` an `ModuleManager.deactivate_module` if current thread is different. The slot method is needed as Pyside2 does not allow to call `invokeMethod` with arguments.

## How Has This Been Tested?
Loaded several dummy modules from `qudi-iqo-modules` and started them from terminal and GUI.

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
