### PR TITLE
Update setup.py for missing qtconsole dependency 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ unix_dep = [
     'ruamel.yaml>=0.17.16',
     'scipy>=1.7.1',
     'jsonschema>=4.2.1',
+    'qtconsole>=5.5.0',
 ]
 
 windows_dep = [
@@ -40,6 +41,7 @@ windows_dep = [
     'ruamel.yaml>=0.17.16',
     'scipy>=1.7.1',
     'jsonschema>=4.2.1',
+    'qtconsole>=5.5.0',
 ]
 
 with open('VERSION', 'r') as file:


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
Adding `qtconsole` as an explicit dependency to `setup.py` since an upstream dependency, `jupyter`, has dropped it but we need it.

## Motivation and Context
See #109.

## How Has This Been Tested?
Tested locally by installing in a fresh conda environment with Python 3.10 on Ubuntu 22.04.4 LTS.

## Screenshots (only if appropriate, delete if not):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [ ] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [ ] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
