### PR TITLE
Bugfix Qtconsole autocomplete

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ None
 
 ### Bugfixes
 - Fixed a bug where qudi would deadlock when starting a GUI module via the ipython terminal
+- Fixed a bug where autocompletion in qtconsole was no longer possible for rpyc version 6.0.0
 
 ### New Features
 None

--- a/src/qudi/core/qudikernel.py
+++ b/src/qudi/core/qudikernel.py
@@ -163,8 +163,10 @@ class QudiIPythonKernel(IPythonKernel):
         # Fixme: Also tried to fix the crazy fomatting scheme of IPython this way. Clashes badly
         #  with rpyc otherwise.
         self.shell.Completer.use_jedi = False
-        self.shell.Completer.evaluation = 'limited'
-        self.config.PlainTextFormatter.pprint = False
+        self.shell.Completer.evaluation = 'unsafe'
+        self.shell.Completer.debug = True
+        #self.config.IPCompleter.use_jedi = False
+        #self.config.PlainTextFormatter.pprint = False
         # self.config.BaseFormatter.enabled = False
         # # lure out first warning and ignore
         # with warnings.catch_warnings():

--- a/src/qudi/core/qudikernel.py
+++ b/src/qudi/core/qudikernel.py
@@ -162,7 +162,8 @@ class QudiIPythonKernel(IPythonKernel):
         #  Jupyter/IPython offer absolutely no documentation on anything not super shallow.
         # Fixme: Also tried to fix the crazy fomatting scheme of IPython this way. Clashes badly
         #  with rpyc otherwise.
-        self.config.IPCompleter.use_jedi = False
+        self.shell.Completer.use_jedi = False
+        self.shell.Completer.evaluation = 'limited'
         self.config.PlainTextFormatter.pprint = False
         # self.config.BaseFormatter.enabled = False
         # # lure out first warning and ignore


### PR DESCRIPTION
## Description
This PR fixes a bug, where the QtConsole and Jupyter-Notebook completer is not working, except for top-level namespace objects such as the individual modules for rpyc==6.0.0. This makes typing in QtConsole `qudi.<Tab>` possible again (or in jupyter-notebook).

## Motivation and Context
When starting qudi, QtConsole connects to the local-namespace-server. This rpyc service has the `exposed_get_namespace_dict` method that returns a dict of all loaded modules. This should make it possible for the qtconsole to autocomplete the loaded modules and their attributes. For rpyc<6.0.0 this works, one can press <Tab> to autocomplete e.g. `qudi` upon startup. Typing `qudi.<Tab>` also autocompletes by giving the list for all attributes of `qudi`.

With rpyc 6.0.0 this no longer works. I found out that this was caused by the `QudiIPythonKernel.shell.Completer.use_jedi` variable. When checking the `QudiIPythonKernel` class one can see in the `__init__` that this has caused some issues in the past and has been fixed already. In fact one can check the config during runtime by typing `get_ipython().Completer.config` in QtConsole. The use_jedi variable is set to `False`. However, when checking the runtime parameters of the Completer by typing `get_ipython().Completer.use_jedi` it is still set to `True`. In rpyc 5.3.1 it seems to work with use_jedi=True.
Installing rpyc 6.0.0 shows the same output of both commands, however autocomplete is only working for the top level modules as e.g. `q<Tab>` which can complete to `qudi`, but `qudi.<Tab>` does not show any results. When setting `get_ipython().Completer.use_jedi = False`, autocompletion works as before. This PR sets this variable directly during init of the Kernel. As the comment in the code above my changes suggests, this is not properly documented how to change the config properly for embedded IPython. Maybe we have to work with a properly set up individual IPython profile or using the `traitlets` module. However, I didn't get it to work quickly so I decided to again go for this workaround.

## How Has This Been Tested?
Testing autocomplete in jupyter-notebook and qtconsole with rpyc 5.3.1 and 6.0.0 installed.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
