### PR TITLE
move remote module poll timer creation before activation

### DIFF
--- a/src/qudi/core/modulemanager.py
+++ b/src/qudi/core/modulemanager.py
@@ -560,11 +560,18 @@ class ManagedModule(QtCore.QObject):
                                                         QtCore.Qt.BlockingQueuedConnection)
                         thread_manager.quit_thread(thread_name)
                         thread_manager.join_thread(thread_name)
+                        self._disconnect()
+                        self._disable_state_updated()
+
             else:
                 try:
                     self._instance.module_state.activate()
-                except fysom.Canceled:
-                    pass
+                except Exception as e:
+                    raise RuntimeError(f'Failed to activate {self.module_base} module "{self.name}"!') from e
+                finally:  # cleanup if activation was not successful
+                    if not self.is_active:
+                        self._disconnect()
+                        self._disable_state_updated()
 
             self.__last_state = self.state
             self.sigStateChanged.emit(self._base, self._name, self.__last_state)
@@ -575,6 +582,7 @@ class ManagedModule(QtCore.QObject):
             if not self.is_active:
                 try:
                     self._disconnect()
+                    self._disable_state_updated()
                 except:
                     pass
                 raise RuntimeError(f'Failed to activate {self.module_base} module "{self.name}"!')
@@ -624,14 +632,7 @@ class ManagedModule(QtCore.QObject):
                     )
                 module.deactivate()
 
-            # Disable state updated
-            try:
-                self.__poll_timer.stop()
-                self.__poll_timer.timeout.disconnect()
-            except AttributeError:
-                self._instance.module_state.sigStateChanged.disconnect(self._state_change_callback)
-            finally:
-                self.__poll_timer = None
+            self._disable_state_updated()
 
             # Actual deactivation of this module
             if self._instance.is_module_threaded:
@@ -763,3 +764,12 @@ class ManagedModule(QtCore.QObject):
     def _disconnect(self):
         with self._lock:
             self._instance.disconnect_modules()
+
+    def _disable_state_updated(self):
+        try:
+            self.__poll_timer.stop()
+            self.__poll_timer.timeout.disconnect()
+        except AttributeError:
+            self._instance.module_state.sigStateChanged.disconnect(self._state_change_callback)
+        finally:
+            self.__poll_timer = None

--- a/src/qudi/core/modulemanager.py
+++ b/src/qudi/core/modulemanager.py
@@ -507,6 +507,15 @@ class ManagedModule(QtCore.QObject):
             if not self.is_loaded:
                 self._load()
 
+            if self.is_remote:
+                self.__poll_timer = QtCore.QTimer(self)
+                self.__poll_timer.setInterval(int(round(self.__state_poll_interval * 1000)))
+                self.__poll_timer.setSingleShot(True)
+                self.__poll_timer.timeout.connect(self._poll_module_state)
+                self.__poll_timer.start()
+            else:
+                self._instance.module_state.sigStateChanged.connect(self._state_change_callback)
+
             # Return early if already active
             if self.is_active:
                 # If it is a GUI module, show it again.
@@ -569,15 +578,6 @@ class ManagedModule(QtCore.QObject):
                 except:
                     pass
                 raise RuntimeError(f'Failed to activate {self.module_base} module "{self.name}"!')
-
-            if self.is_remote:
-                self.__poll_timer = QtCore.QTimer(self)
-                self.__poll_timer.setInterval(int(round(self.__state_poll_interval * 1000)))
-                self.__poll_timer.setSingleShot(True)
-                self.__poll_timer.timeout.connect(self._poll_module_state)
-                self.__poll_timer.start()
-            else:
-                self._instance.module_state.sigStateChanged.connect(self._state_change_callback)
 
     @QtCore.Slot()
     def _poll_module_state(self):


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->
create a poll timer (for remote modules) or connect the state changed signal (for local modules) before checking whether the module is already active

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If a module is already active on the server while the client connects, the activate method returns early and no poll timer is created. This causes the module to not deactivate cleanly later on (fixes #57 and the duplicate issue #61).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
running a server and a client qudi instance on the same machine with data instream dummy from iqo-modules


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
