### PR TITLE
Hotfix for issue #123

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ None
 - Fixed a bug where qudi would deadlock when starting a GUI module via the ipython terminal
 - Fixed a bug with the `qtconsole` package no longer being part of `jupyter`. It is now listed 
 explicitly in the dependencies.
+- Fixed SystemTrayIcon error when activating GUI modules
 
 ### New Features
 None

--- a/src/qudi/core/modulemanager.py
+++ b/src/qudi/core/modulemanager.py
@@ -592,7 +592,6 @@ class ManagedModule(QtCore.QObject):
     def _poll_module_state(self):
         with self._lock:
             state = self.state
-            logger.debug(state)
             if state != self.__last_state:
                 self.__last_state = state
                 self.sigStateChanged.emit(self._base, self._name, state)

--- a/src/qudi/core/modulemanager.py
+++ b/src/qudi/core/modulemanager.py
@@ -575,7 +575,7 @@ class ManagedModule(QtCore.QObject):
                         self._disable_state_updated()
 
             self.__last_state = self.state
-            self.sigStateChanged.emit(self._base, self._name, self.__last_state)
+
             self.sigAppDataChanged.emit(self._base, self._name, self.has_app_data)
 
             # Raise exception if by some reason no exception propagated to here and the activation


### PR DESCRIPTION
## Description
Fixes issue #123 by removing second emitting of signal

## Motivation and Context
Error in #123 is thrown on every GUI module load

## How Has This Been Tested?
instream dummy toolchain from iqo sequences, with remote instreamer and local instreamer dummy

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
