### PR TITLE
fix TextDataStorage load_data

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,9 +7,10 @@ None
 
 ### Bugfixes
 - Fixed a bug where qudi would deadlock when starting a GUI module via the ipython terminal
-- Fixed a bug with the `qtconsole` package no longer being part of `jupyter`. It is now listed 
+- Fixed a bug with the `qtconsole` package no longer being part of `jupyter`. It is now listed
 explicitly in the dependencies.
 - Fixed SystemTrayIcon error when activating GUI modules
+- Fixed `TextDataStorage` to load all lines of data and not skip the first line of data
 
 ### New Features
 None
@@ -30,7 +31,7 @@ None
 - Fixed syntax error in `qudi.util.fit_models.lorentzian.LorentzianLinear` fit model
 
 ### New Features
-- Introduced `DiscreteScalarConstraint` that expands the functionality of `ScalarConstraint` to check whether a value 
+- Introduced `DiscreteScalarConstraint` that expands the functionality of `ScalarConstraint` to check whether a value
 is in a set of discrete values
 
 ### Other

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ None
 - Fixed a bug with the `qtconsole` package no longer being part of `jupyter`. It is now listed
 explicitly in the dependencies.
 - Fixed SystemTrayIcon error when activating GUI modules
-- Fixed `TextDataStorage` to load all lines of data and not skip the first line of data
+- Fixed `TextDataStorage.load_data` to load all lines of data and not skip the first line of data
 
 ### New Features
 None

--- a/src/qudi/util/datastorage.py
+++ b/src/qudi/util/datastorage.py
@@ -725,7 +725,7 @@ class TextDataStorage(DataStorageBase):
                                  dtype=dtype,
                                  comments=general['comments'],
                                  delimiter=general['delimiter'],
-                                 skip_header=header_lines + 2)
+                                 skip_header=header_lines + 1)
         except UnicodeError as err:
             raise ValueError(f'Loading data from file "{file_path}" failed. The file you are '
                              f'trying to load is most likely no unicode textfile.') from err


### PR DESCRIPTION
## Description
`TextDataStorage` correctly loads all lines of data in a measurement data txt file.

## Motivation and Context
When using `TextDataStorage` to load data from a txt file, saved with the same interface, the first line of data is skipped.
This is due to a `+2` added in the `np.genfromtxt` call option `skip_header`. Changing to a `+1` correctly loads all lines of data.

## How Has This Been Tested?
Confocal setup and dummy modules.

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
