### PR TITLE
NpyDataStorage class fix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ None
 explicitly in the dependencies.
 - Fixed SystemTrayIcon error when activating GUI modules
 - Fixed `TextDataStorage.load_data` to load all lines of data and not skip the first line of data
+- Fixed `NpyDataStorage.load_data` exception when loading metadata
 
 ### New Features
 None

--- a/src/qudi/util/datastorage.py
+++ b/src/qudi/util/datastorage.py
@@ -887,7 +887,7 @@ class NpyDataStorage(DataStorageBase):
         # Try to find and load metadata from text file
         metadata_path = file_path.split('.npy')[0] + '_metadata.txt'
         try:
-            header = get_header_from_file(metadata_path)
+            header, _ = get_header_from_file(metadata_path)
         except FileNotFoundError:
             return data, dict(), dict()
         metadata, general = get_info_from_header(header)


### PR DESCRIPTION
## Description
Fixes exception `TypeError: initial_value must be str or None, not tuple`, thrown when calling `NpyDataStorage.load_data`.
Within the function, when loading the metadata the function `get_header_from_file` is called.
This function returns 2 variables (`header` and `header_lines`).
`header` is used in the function `get_info_from_header` to extract general metadata and specific metadata.
In `NpyDataStorage` the second return value `header_lines` is not caught, thus a tuple `(header, header_lines)` is passed to `get_info_from_header`, causing the above exception.

This PR fixes the issue by capturing `header_lines` to `_`, similar to how it is done in the other data storage classes.

## How Has This Been Tested?
Jupyter Notebook calling `NpyDataStorage.load_data(file_path)` on a file created by the `qudi-iqo-modules.pulsed_measurement_logic.save_measurement_data(storage_cls=NpyDataStorage)`

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
