### PR TITLE
CsvDataStorage fix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ None
 explicitly in the dependencies.
 - Fixed SystemTrayIcon error when activating GUI modules
 - Fixed `TextDataStorage.load_data` to load all lines of data and not skip the first line of data
+- Fixed `CsvDataStorage.load_data` to load all lines of data and not skip the first line of data
 
 ### New Features
 None

--- a/src/qudi/util/datastorage.py
+++ b/src/qudi/util/datastorage.py
@@ -793,7 +793,7 @@ class CsvDataStorage(TextDataStorage):
             else:
                 dtype = [(f'f{col:d}', typ) for col, typ in enumerate(dtype)]
         # Load data from file and skip header
-        start_line = header_lines + 2
+        start_line = header_lines + 1
         if general['column_headers']:
             start_line += 1
         data = np.genfromtxt(file_path,


### PR DESCRIPTION
## Description
`CsvDataStorage` correctly loads all lines of data in a measurement data csv file. Fix is similar to fix in #128.

## Motivation and Context
When using `CsvDataStorage` to load data from a csv file, saved with the same interface, the first line of data is skipped.
This is due to a `+2` added in the `np.genfromtxt` call option `skip_header`. Changing to a `+1` correctly loads all lines of data.

## How Has This Been Tested?
Jupyter Notebook calling `CsvDataStorage.load_data(file_path)` on a file created by the `qudi-iqo-modules.pulsed_measurement_logic.save_measurement_data(storage_cls=CsvDataStorage)`

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
