### PR TITLE
`NpyDataStorage` metadata loading fix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@
 None
 
 ### Bugfixes
-None
+- Fixed the correct assignment of `metadata` and `general` when loading data with `NpyDataStorage`, in line with the other storage classes
 
 ### New Features
 None

--- a/src/qudi/util/datastorage.py
+++ b/src/qudi/util/datastorage.py
@@ -890,5 +890,5 @@ class NpyDataStorage(DataStorageBase):
             header, _ = get_header_from_file(metadata_path)
         except FileNotFoundError:
             return data, dict(), dict()
-        metadata, general = get_info_from_header(header)
+        general, metadata = get_info_from_header(header)
         return data, metadata, general


### PR DESCRIPTION
<!--- Provide a general short and descriptive title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a bug where `metadata` and `general` metadata dictionaries are switched in `NpyDataStorage.load_data` in comparison to the other data storage classes.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, when loading data with `NpyDataStorage.load_data` the corresponding `general` metadata and `metadata` variables are switched in the position they are returned from the method.
This is unexpected with the behavior of the other storage classes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Loading data with the new `qdyne` module of `qudi-iqo-modules` package. 

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] Bug fix
- [ ] New feature
- [x] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an 'x' in all the boxes that apply, e.g. "[x]". -->
<!--- If you're unsure about any of these, ask. -->
<!--- You can also create this PR and afterwards check the boxes by clicking on them. -->
- [x] My code follows the code style of this project.
- [x] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
