### PR TITLE
fixing mro issue for rpyc>6.0

### DIFF
--- a/src/qudi/core/connector.py
+++ b/src/qudi/core/connector.py
@@ -113,8 +113,7 @@ class Connector(Generic[M]):
     def connect(self, target: M) -> None:
         """Check if target is connectible by this connector and connect.
         """
-        bases = {cls.__name__ for cls in target.__class__.mro()}
-        if self.interface not in bases:
+        if self.interface not in self._interface_names(target):
             raise RuntimeError(
                 f'Module "{target}" connected to connector "{self.name}" does not implement '
                 f'interface "{self.interface}".'
@@ -122,6 +121,18 @@ class Connector(Generic[M]):
         self._obj_proxy = OverloadProxy(target, self.interface)
         self._obj_ref = weakref.ref(target, self.__module_died_callback)
 
+    @staticmethod
+    def _interface_names(target: M) -> set:
+        """Class names in the target's MRO.
+
+        For remote modules this resolves server-side and only strings cross the
+        rpyc connection. Falls back to a local MRO walk for non-Base targets.
+        """
+        try:
+            return set(target.module_interface_names)
+        except AttributeError:
+            return {cls.__name__ for cls in target.__class__.mro()}
+    
     def disconnect(self) -> None:
         """Disconnect connector.
         """

--- a/src/qudi/core/module.py
+++ b/src/qudi/core/module.py
@@ -270,6 +270,18 @@ class Base(QtCore.QObject, metaclass=ModuleMeta):
             self.log.exception('Error while collecting status variables:')
         return variables
 
+    
+    @property
+    def module_interface_names(self) -> tuple:
+        """Names of every class in this module's MRO.
+
+        Accessed through an rpyc netref, this getter runs on the server where
+        type(self) is the real class. Only a tuple of strings crosses the
+        connection, so it is immune
+        to the rpyc>=6 bug that mangles class objects sent over the wire.
+        """
+        return tuple(cls.__name__ for cls in type(self).mro())
+
     @property
     def _qudi_main(self) -> Any:
         qudi_main = self.__qudi_main_weakref()


### PR DESCRIPTION
This is a workaround solution for the issue #114 raised by @qku 

## Description
rpyc>=6 breaks connectors to remote modules. The problem is detailed in the issue #114

## Motivation and Context
Any class or type object that crosses the rpyc 6 connection comes back broken. So, the mro() walk gets mangled for netref class. One way to overcome this is to do the mro() resolution on the server side as a property of the base module, and storing it as a tuple which would be then sent remotely where the connector performs the check.

## How Has This Been Tested?
This has been tested locally with dummy remote configuration for multiple modules with rpyc v6.0.2


## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in `/docs/changelog.md`.
- [ ] My change requires additional/updated documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated the config example for any module docstrings as necessary.
- [x] I have checked that the change does not contain obvious errors
(syntax, indentation, mutable default values, etc.).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
